### PR TITLE
Content type 4 public api

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,18 +27,18 @@ done using `Content-type`, `Accept` and `Accept-Charset` headers.
 
 ### Request
 
-* `:muuntaja.core/adapter`, holds the adapter name that was used to decode the request body, e.g. `:json`.
+* `:muuntaja.core/format`, format name that was used to decode the request body, e.g. `"application/json"`.
    Setting value to anything (e.g. `nil`) before muuntaja middleware/interceptor will skip the decoding process.
-* `:muuntaja.core/accept`, holds the client-negotiated adapter name for the response, e.g. `:json`. Will be used
-   later in the response pipeline.
+* `:muuntaja.core/accept`, client-negotiated format name for the response, e.g. `"application/json"`. Will
+   be used later in the response pipeline.
 
 ### Response
 
 * `:muuntaja.core/encode?`, if set to true, the response body will be encoded regardles of the type
-* `:muuntaja.core/adapter`, holds the adapter name that was used to encode the response body, e.g. `:json`.
+* `:muuntaja.core/format`, format name that was used to encode the response body, e.g. `"application/json"`.
    Setting value to anything (e.g. `nil`) before muuntaja middleware/interceptor will skip the encoding process.
 * `:muuntaja.core/content-type`, can be used to override the negotiated content-type for response encoding,
-   e.g. setting it to `application/edn` will cause the response to encoded always with the `:edn` adapter.
+   e.g. setting it to `application/edn`. **NOTE**: given format is not negotiated, always set on.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Creating a muuntaja and using it to encode & decode JSON:
 
 (->> {:kikka 42}
      (m/encode m "application/json")
-     (m/decode m "application/json))
+     (m/decode m "application/json"))
 ; {:kikka 42}
 ```
 
@@ -99,7 +99,7 @@ Middleware with defaults:
       :body "{\"kikka\":42}"})
 ; {:status 200
 ;  :body "{:kikka 42}"
-;  :muuntaja.core/adapter :edn
+;  :muuntaja.core/format "application/edn"
 ;  :headers {"Content-Type" "application/edn; charset=utf-8"}}
 ```
 
@@ -112,7 +112,7 @@ Middleware with defaults:
  :decode? (constantly true)
  :encode? encode-collections-with-override
  :charset "utf-8"
- ;charsets #{"utf-8", "utf-16", "iso-8859-1"
+ ;charsets #{"utf-8", "utf-16", "iso-8859-1"}
  :formats {"application/json" {:matches #"application/(.+\+)?json"
                                :decoder [formats/make-json-decoder {:keywords? true}]
                                :encoder [formats/make-json-encoder]

--- a/project.clj
+++ b/project.clj
@@ -5,8 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo
             :comments "same as Clojure"}
-  :dependencies [[ring/ring-core "1.5.0" :exclusions [commons-codec]]
-                 [cheshire "5.6.3" :exclusions [com.fasterxml.jackson.core/jackson-core]]
+  :dependencies [[cheshire "5.6.3" :exclusions [com.fasterxml.jackson.core/jackson-core]]
                  [com.fasterxml.jackson.core/jackson-databind "2.8.3"]
                  [circleci/clj-yaml "0.5.5"]
                  [clojure-msgpack "1.2.0" :exclusions [org.clojure/clojure]]

--- a/src/muuntaja/core.clj
+++ b/src/muuntaja/core.clj
@@ -113,10 +113,20 @@
 
   Formatter
   (encoder [_ format]
-    (-> format adapters :encode))
+    (or (-> format adapters :encode)
+        (throw
+          (ex-info
+            (str "invalid encoder format: " format)
+            {:formats (keys adapters)
+             :format format}))))
 
   (decoder [_ format]
-    (-> format adapters :decode)))
+    (or (-> format adapters :decode)
+        (throw
+          (ex-info
+            (str "invalid decoder format: " format)
+            {:formats (keys adapters)
+             :format format})))))
 
 (defn encode [formats format data]
   (if-let [encode (encoder formats format)]

--- a/src/muuntaja/core.clj
+++ b/src/muuntaja/core.clj
@@ -88,8 +88,6 @@
                     encode?
                     decode?
 
-                    encode-error-fn
-
                     consumes
                     matchers
 
@@ -368,3 +366,5 @@
 
 (defn set-response-content-type [response content-type]
   (assoc response ::content-type content-type))
+
+(create default-options)

--- a/src/muuntaja/core.clj
+++ b/src/muuntaja/core.clj
@@ -89,7 +89,6 @@
                     matchers
 
                     adapters
-                    formats
                     default-format]
   RequestFormatter
 
@@ -286,7 +285,7 @@
    :decode? (constantly true)
    :encode? encode-collections-with-override
    :charset "utf-8"
-   ;charsets #{"utf-8", "utf-16", "iso-8859-1"
+   ;charsets #{"utf-8", "utf-16", "iso-8859-1"}
    :formats {"application/json" {:matches #"application/(.+\+)?json"
                                  :decoder [formats/make-json-decoder {:keywords? true}]
                                  :encoder [formats/make-json-encoder]
@@ -374,5 +373,3 @@
 
 (defn set-response-content-type [response content-type]
   (assoc response ::content-type content-type))
-
-(create default-options)

--- a/src/muuntaja/core.clj
+++ b/src/muuntaja/core.clj
@@ -102,13 +102,13 @@
 
   (decode-request? [_ request]
     (and decode?
-         (not (contains? request ::adapter))
+         (not (contains? request ::format))
          (decode? request)))
 
   (encode-response? [_ request response]
     (and encode?
          (map? response)
-         (not (contains? response ::adapter))
+         (not (contains? response ::format))
          (encode? request response)))
 
   Formatter
@@ -220,7 +220,7 @@
           (if (and body decoder)
             (try
               (-> $
-                  (assoc ::adapter ctf)
+                  (assoc ::format ctf)
                   (assoc :body nil)
                   (assoc :body-params (decoder body)))
               (catch Exception e
@@ -235,7 +235,8 @@
                      (:default-format formats))]
       (if-let [encoder (encoder formats format)]
         (as-> response $
-              (assoc $ ::adapter format)
+              (assoc $ ::format format)
+              (dissoc $ ::content-type)
               (update $ :body encoder)
               (if-not (get (:headers $) "Content-Type")
                 (set-content-type $ (content-type formats format))
@@ -351,14 +352,14 @@
 ;;
 
 (defn disable-request-decoding [request]
-  (assoc request ::adapter nil))
+  (assoc request ::format nil))
 
 ;;
 ;; response helpers
 ;;
 
 (defn disable-response-encoding [response]
-  (assoc response ::adapter nil))
+  (assoc response ::format nil))
 
 (defn set-response-content-type [response content-type]
   (assoc response ::content-type content-type))

--- a/src/muuntaja/core.clj
+++ b/src/muuntaja/core.clj
@@ -229,8 +229,10 @@
 
 ;; TODO: use the negotiated response charset
 (defn format-response [formats request response]
+  (or
   (if (encode-response? formats request response)
-    (let [format (or ((:produces formats) (::content-type response))
+      (if-let [format (or (if-let [ct (::content-type response)]
+                            ((:produces formats) ct))
                      (::accept request)
                      (:default-format formats))]
       (if-let [encoder (encoder formats format)]
@@ -240,8 +242,7 @@
               (update $ :body encoder)
               (if-not (get (:headers $) "Content-Type")
                 (set-content-type $ (content-type formats format))
-                $))
-        response))
+                  $)))))
     response))
 
 ;;

--- a/src/muuntaja/core.clj
+++ b/src/muuntaja/core.clj
@@ -1,6 +1,7 @@
 (ns muuntaja.core
   (:require [muuntaja.parse :as parse]
-            [muuntaja.formats :as formats]))
+            [muuntaja.formats :as formats]
+            [clojure.set :as set]))
 
 (defn- some-value [pred c]
   (let [f (fn [x] (if (pred x) x))]
@@ -36,40 +37,36 @@
 
 (defprotocol Formatter
   (encoder [_ format])
-  (decoder [_ format])
-  (default-format [_]))
+  (decoder [_ format]))
 
 ;;
 ;; Content negotiation
 ;;
 
-(defn- -negotiate-content-type [{:keys [consumes matchers charset]} ^String s]
+(defn- -negotiate-content-type [{:keys [consumes matchers charset]} s]
   (if s
     (let [[content-type-raw charset-raw] (parse/parse-content-type s)]
       [(if content-type-raw
-         (or (get consumes content-type-raw)
-             (loop [i 0]
-               (let [[f r] (nth matchers i)]
-                 (cond
-                   (re-find r content-type-raw) f
-                   (< (inc i) (count matchers)) (recur (inc i)))))))
+         (or (consumes content-type-raw)
+             (some
+               (fn [[name r]]
+                 (if (re-find r content-type-raw) name))
+               matchers)))
        (or charset-raw charset)])))
 
-(defn- -negotiate-accept [{:keys [consumes produces] :as formats} ^String s]
-  (consumes
-    (or
-      (some-value
-        consumes
-        (parse/parse-accept s))
-      (produces
-        (default-format formats)))))
-
-(defn- -negotiate-accept-charset [formats s]
+(defn- -negotiate-accept [{:keys [produces default-format]} s]
   (or
     (some-value
-      (or (:charsets formats) identity)
+      produces
+      (parse/parse-accept s))
+    default-format))
+
+(defn- -negotiate-accept-charset [{:keys [charset charsets]} s]
+  (or
+    (some-value
+      (or charsets identity)
       (parse/parse-accept-charset s))
-    (:charset formats)))
+    charset))
 
 ;;
 ;; Records
@@ -119,63 +116,43 @@
     (-> format adapters :encode))
 
   (decoder [_ format]
-    (-> format adapters :decode))
-
-  (default-format [_]
-    default-format))
+    (-> format adapters :decode)))
 
 (defn encode [formats format data]
   (if-let [encode (encoder formats format)]
-    (encode data)))
+    (encode data)
+    (throw
+      (ex-info
+        (str "invalid encode format: " format)
+        {:formats (-> formats :formats keys)
+         :format format}))))
 
 (defn decode [formats format data]
   (if-let [decode (decoder formats format)]
-    (decode data)))
+    (decode data)
+    (throw
+      (ex-info
+        (str "invalid decode format: " format)
+        {:formats (-> formats :formats keys)
+         :format format}))))
 
 ;;
-;; Content-type resolution
+;; Creation
 ;;
 
-(defn- content-type->format [format-types]
-  (reduce
-    (fn [acc [k type]]
-      (let [old-k (acc type)]
-        (when (and old-k (not= old-k k))
-          (throw (ex-info "content-type refers to multiple formats" {:content-type type
-                                                                     :formats [k old-k]}))))
-      (assoc acc type k))
-    {}
-    (for [[k type-or-types] format-types
-          :let [types (flatten (vector type-or-types))]
-          type types
-          :when (string? type)]
-      [k type])))
+(defn- key-set [m accept?]
+  (set
+    (for [[k v] m
+          :when (accept? v)]
+      k)))
 
-(defn- format-regexps [format-types]
-  (reduce
-    (fn [acc [k type]]
-      (conj acc [k type]))
-    []
-    (for [[k type-or-types] format-types
-          :let [types (flatten (vector type-or-types))]
-          type types
-          :when (not (string? type))]
-      [k type])))
+(defn- matchers [formats]
+  (->>
+    (for [[name {:keys [matches]}] formats]
+      [name matches])
+    (into {})))
 
-(defn- format->content-type [format-types]
-  (reduce
-    (fn [acc [k type]]
-      (if-not (acc k)
-        (assoc acc k type)
-        acc))
-    {}
-    (for [[k type-or-types] format-types
-          :let [types (flatten (vector type-or-types))]
-          type types
-          :when (string? type)]
-      [k type])))
-
-(defn- compile-adapters [adapters formats]
+(defn- create-adapters [formats]
   (let [make (fn [spec spec-opts [p pf]]
                (let [g (if (vector? spec)
                          (let [[f opts] spec]
@@ -187,33 +164,29 @@
                        (pf x)
                        (g x)))
                    g)))]
-    (->> formats
-         (keep identity)
-         (mapv (fn [format]
-                 (if-let [{:keys [decoder decoder-opts encoder encoder-opts encode-protocol] :as adapter}
-                          (if (map? format) format (get adapters format))]
-                   [format (map->Adapter
-                             (merge
-                               (if decoder {:decode (make decoder decoder-opts nil)})
-                               (if encoder {:encode (make encoder encoder-opts encode-protocol)})))]
-                   (throw (ex-info (str "no adapter for: " format) {:supported (keys adapters)
-                                                                    :format format})))))
+    (->> (for [[name {:keys [decoder decoder-opts encoder encoder-opts encode-protocol]}] formats]
+           [name (map->Adapter
+                   (merge
+                     (if decoder {:decode (make decoder decoder-opts nil)})
+                     (if encoder {:encode (make encoder encoder-opts encode-protocol)})))])
          (into {}))))
 
-(defn create [{:keys [adapters formats] :as options}]
-  (let [selected-format? (set formats)
-        format-types (for [[k {:keys [format]}] adapters
-                           :when (selected-format? k)]
-                       [k format])
-        adapters (compile-adapters adapters formats)
+(defn create [{:keys [formats default-format] :as options}]
+  (let [adapters (create-adapters formats)
+        valid-format? (key-set formats identity)
         m (map->Formats
             (merge
-              options
-              {:default-format (first formats)
-               :adapters adapters
-               :consumes (content-type->format format-types)
-               :produces (format->content-type format-types)
-               :matchers (format-regexps format-types)}))]
+              (dissoc options :formats)
+              {:adapters adapters
+               :consumes (key-set formats :decoder)
+               :produces (key-set formats :encoder)
+               :matchers (matchers formats)}))]
+    (when-not (valid-format? default-format)
+      (throw
+        (ex-info
+          (str "Invalid default format " default-format)
+          {:formats valid-format?
+           :default-format default-format})))
     (-> m
         (assoc
           :negotiate-accept-charset
@@ -257,9 +230,9 @@
 ;; TODO: use the negotiated response charset
 (defn format-response [formats request response]
   (if (encode-response? formats request response)
-    (let [format (or (get (:consumes formats) (::content-type response))
+    (let [format (or ((:produces formats) (::content-type response))
                      (::accept request)
-                     (default-format formats))]
+                     (:default-format formats))]
       (if-let [encoder (encoder formats format)]
         (as-> response $
               (assoc $ ::adapter format)
@@ -271,7 +244,7 @@
     response))
 
 ;;
-;; customization
+;; Options
 ;;
 
 (defn extract-content-type-ring
@@ -302,53 +275,76 @@
    :encode? encode-collections-with-override
    :charset "utf-8"
    ;charsets #{"utf-8", "utf-16", "iso-8859-1"
-   :adapters {:json {:format ["application/json" #"application/(.+\+)?json"]
-                     :decoder [formats/make-json-decoder {:keywords? true}]
-                     :encoder [formats/make-json-encoder]
-                     :encode-protocol [formats/EncodeJson formats/encode-json]}
-              :edn {:format ["application/edn" #"^application/(vnd.+)?(x-)?(clojure|edn)"]
-                    :decoder [formats/make-edn-decoder]
-                    :encoder [formats/make-edn-encoder]
-                    :encode-protocol [formats/EncodeEdn formats/encode-edn]}
-              :msgpack {:format ["application/msgpack" #"^application/(vnd.+)?(x-)?msgpack"]
-                        :decoder [formats/make-msgpack-decoder {:keywords? true}]
-                        :encoder [formats/make-msgpack-encoder]
-                        :encode-protocol [formats/EncodeMsgpack formats/encode-msgpack]}
-              :yaml {:format ["application/x-yaml" #"^(application|text)/(vnd.+)?(x-)?yaml"]
-                     :decoder [formats/make-yaml-decoder {:keywords true}]
-                     :encoder [formats/make-yaml-encoder]
-                     :encode-protocol [formats/EncodeYaml formats/encode-yaml]}
-              :transit-json {:format ["application/transit+json" #"^application/(vnd.+)?(x-)?transit\+json"]
-                             :decoder [(partial formats/make-transit-decoder :json)]
-                             :encoder [(partial formats/make-transit-encoder :json)]
-                             :encode-protocol [formats/EncodeTransitJson formats/encode-transit-json]}
-              :transit-msgpack {:format ["application/transit+msgpack" #"^application/(vnd.+)?(x-)?transit\+msgpack"]
-                                :decoder [(partial formats/make-transit-decoder :msgpack)]
-                                :encoder [(partial formats/make-transit-encoder :msgpack)]
-                                :encode-protocol [formats/EncodeTransitMessagePack formats/encode-transit-msgpack]}}
-   :formats [:json :edn :msgpack :yaml :transit-json :transit-msgpack]})
+   :formats {"application/json" {:matches #"application/(.+\+)?json"
+                                 :decoder [formats/make-json-decoder {:keywords? true}]
+                                 :encoder [formats/make-json-encoder]
+                                 :encode-protocol [formats/EncodeJson formats/encode-json]}
+             "application/edn" {:matches #"^application/(vnd.+)?(x-)?(clojure|edn)"
+                                :decoder [formats/make-edn-decoder]
+                                :encoder [formats/make-edn-encoder]
+                                :encode-protocol [formats/EncodeEdn formats/encode-edn]}
+             "application/msgpack" {:matches #"^application/(vnd.+)?(x-)?msgpack"
+                                    :decoder [formats/make-msgpack-decoder {:keywords? true}]
+                                    :encoder [formats/make-msgpack-encoder]
+                                    :encode-protocol [formats/EncodeMsgpack formats/encode-msgpack]}
+             "application/x-yaml" {:matches #"^(application|text)/(vnd.+)?(x-)?yaml"
+                                   :decoder [formats/make-yaml-decoder {:keywords true}]
+                                   :encoder [formats/make-yaml-encoder]
+                                   :encode-protocol [formats/EncodeYaml formats/encode-yaml]}
+             "application/transit+json" {:matches #"^application/(vnd.+)?(x-)?transit\+json"
+                                         :decoder [(partial formats/make-transit-decoder :json)]
+                                         :encoder [(partial formats/make-transit-encoder :json)]
+                                         :encode-protocol [formats/EncodeTransitJson formats/encode-transit-json]}
+             "application/transit+msgpack" {:matches #"^application/(vnd.+)?(x-)?transit\+msgpack"
+                                            :decoder [(partial formats/make-transit-decoder :msgpack)]
+                                            :encoder [(partial formats/make-transit-encoder :msgpack)]
+                                            :encode-protocol [formats/EncodeTransitMessagePack formats/encode-transit-msgpack]}}
+   :default-format "application/json"})
 
 ;;
 ;; Working with options
 ;;
 
-(defn transform-adapter-options [f options]
-  (update options :adapters #(into (empty %) (map (fn [[k v]] [k (f v)]) %))))
+(defn transform-format-options [f options]
+  (update options :formats #(into (empty %) (map (fn [[k v]] [k (f v)]) %))))
 
-(def no-decoding (partial transform-adapter-options #(dissoc % :decoder)))
-(def no-encoding (partial transform-adapter-options #(dissoc % :encoder)))
+(def no-decoding (partial transform-format-options #(dissoc % :decoder)))
+(def no-encoding (partial transform-format-options #(dissoc % :encoder)))
 
 (def no-protocol-encoding
-  (partial transform-adapter-options #(dissoc % :encode-protocol)))
+  (partial transform-format-options #(dissoc % :encode-protocol)))
 
 (defn with-decoder-opts [options format opts]
-  (assoc-in options [:adapters format :decoder-opts] opts))
+  (when-not (get-in options [:formats format])
+    (throw
+      (ex-info
+        (str "invalid format: " format)
+        {:format format
+         :formats (keys (:formats options))})))
+  (assoc-in options [:formats format :decoder-opts] opts))
 
 (defn with-encoder-opts [options format opts]
-  (assoc-in options [:adapters format :encoder-opts] opts))
+  (when-not (get-in options [:formats format])
+    (throw
+      (ex-info
+        (str "invalid format: " format)
+        {:format format
+         :formats (keys (:formats options))})))
+  (assoc-in options [:formats format :encoder-opts] opts))
 
 (defn with-formats [options formats]
-  (assoc options :formats formats))
+  (let [existing-formats (-> options :formats keys set)
+        future-formats (set formats)]
+    (when-let [diff (seq (set/difference future-formats existing-formats))]
+      (throw
+        (ex-info
+          (str "invalid formats: " diff)
+          {:invalid (seq diff)
+           :formats (seq formats)
+           :existing (seq existing-formats)})))
+    (-> options
+        (update :formats select-keys formats)
+        (assoc :default-format (first formats)))))
 
 ;;
 ;; request helpers

--- a/src/muuntaja/core.clj
+++ b/src/muuntaja/core.clj
@@ -112,20 +112,10 @@
 
   Formatter
   (encoder [_ format]
-    (or (-> format adapters :encode)
-        (throw
-          (ex-info
-            (str "invalid encoder format: " format)
-            {:formats (keys adapters)
-             :format format}))))
+    (-> format adapters :encode))
 
   (decoder [_ format]
-    (or (-> format adapters :decode)
-        (throw
-          (ex-info
-            (str "invalid decoder format: " format)
-            {:formats (keys adapters)
-             :format format})))))
+    (-> format adapters :decode)))
 
 (defn encode [formats format data]
   (if-let [encode (encoder formats format)]
@@ -239,18 +229,18 @@
 ;; TODO: use the negotiated response charset
 (defn format-response [formats request response]
   (or
-  (if (encode-response? formats request response)
+    (if (encode-response? formats request response)
       (if-let [format (or (if-let [ct (::content-type response)]
                             ((:produces formats) ct))
-                     (::accept request)
-                     (:default-format formats))]
-      (if-let [encoder (encoder formats format)]
-        (as-> response $
-              (assoc $ ::format format)
-              (dissoc $ ::content-type)
-              (update $ :body encoder)
-              (if-not (get (:headers $) "Content-Type")
-                (set-content-type $ (content-type formats format))
+                          (::accept request)
+                          (:default-format formats))]
+        (if-let [encoder (encoder formats format)]
+          (as-> response $
+                (assoc $ ::format format)
+                (dissoc $ ::content-type)
+                (update $ :body encoder)
+                (if-not (get (:headers $) "Content-Type")
+                  (set-content-type $ (content-type formats format))
                   $)))))
     response))
 

--- a/src/muuntaja/interceptor.clj
+++ b/src/muuntaja/interceptor.clj
@@ -1,5 +1,5 @@
 (ns muuntaja.interceptor
-  (:require [muuntaja.core :as muuntaja]))
+  (:require [muuntaja.core :as m]))
 
 (defrecord Interceptor [name enter leave])
 
@@ -8,6 +8,6 @@
     (map->Interceptor
       {:name ::format
        :enter (fn [ctx]
-                (update ctx :request (partial muuntaja/format-request formats)))
+                (update ctx :request (partial m/format-request formats)))
        :leave (fn [ctx]
-                (update ctx :response (partial muuntaja/format-response formats (:request ctx))))})))
+                (update ctx :response (partial m/format-response formats (:request ctx))))})))

--- a/src/muuntaja/middleware.clj
+++ b/src/muuntaja/middleware.clj
@@ -13,7 +13,7 @@
     (handler request)
     (catch Exception e
       (if-let [data (ex-data e)]
-        (if (-> data :type (= ::muuntaja/decode))
+        (if (-> data :type (= ::m/decode))
           (on-exception e (:format data) request)
           (throw e))
         (throw e)))))

--- a/src/muuntaja/middleware.clj
+++ b/src/muuntaja/middleware.clj
@@ -1,5 +1,5 @@
 (ns muuntaja.middleware
-  (:require [muuntaja.core :as muuntaja])
+  (:require [muuntaja.core :as m])
   (:import [muuntaja.core Formats]))
 
 ; [^Exception e format request]
@@ -34,15 +34,15 @@
 
 (defn wrap-format
   ([handler]
-   (wrap-format handler muuntaja/default-options))
+   (wrap-format handler m/default-options))
   ([handler options-or-formats]
    (let [formats (if (instance? Formats options-or-formats)
                    options-or-formats
-                   (muuntaja/create options-or-formats))]
+                   (m/create options-or-formats))]
      (fn
        ([request]
-        (let [req (muuntaja/format-request formats request)]
-          (->> (handler req) (muuntaja/format-response formats req))))
+        (let [req (m/format-request formats request)]
+          (->> (handler req) (m/format-response formats req))))
        ([request respond raise]
-        (let [req (muuntaja/format-request formats request)]
-          (handler req #(respond (muuntaja/format-response formats req %)) raise)))))))
+        (let [req (m/format-request formats request)]
+          (handler req #(respond (m/format-response formats req %)) raise)))))))

--- a/test/muuntaja/core_perf_test.clj
+++ b/test/muuntaja/core_perf_test.clj
@@ -33,7 +33,8 @@
 
 (def +transit-json-request+
   {:headers {"content-type" "application/transit+json"
-             "accept" "application/transit+json; charset=utf-16"}
+             "accept" "application/transit+json"
+             "accept-charset" "utf-16"}
    :body "[\"^ \",\"~:kikka\",42]"})
 
 (defrecord Hello [^String name]
@@ -110,14 +111,14 @@
 ;;
 
 (defn content-type []
-  (let [m (-> m/default-options m/no-decoding m/no-encoding m/create)]
+  (let [m (m/create m/default-options)]
 
     ; 52ns
     ; 38ns consumes & produces (-27%)
     ; 27ns compile (-29%) (-48%)
     ; 49ns + charset, memoized
     (title "Content-type: JSON")
-    (assert [:json "utf-8"] (m/negotiate-request m +json-request+))
+    (assert (= ["application/json" "utf-8"] (m/negotiate-request m +json-request+)))
     (cc/quick-bench (m/negotiate-request m +json-request+))
 
     ; 65ns
@@ -125,22 +126,22 @@
     ; 42ns compile (-24%) (-35%)
     ; 48ns + charset, memoized
     (title "Content-type: TRANSIT")
-    (assert [:transit-json "utf-16"] (m/negotiate-request m +transit-json-request+))
+    (assert (= ["application/transit+json" "utf-16"] (m/negotiate-request m +transit-json-request+)))
     (cc/quick-bench (m/negotiate-request m +transit-json-request+))))
 
 (defn accept []
-  (let [m (-> m/default-options m/no-decoding m/no-encoding m/create)]
+  (let [m (m/create m/default-options)]
 
     ; 71ns
     ; 58ns consumes & produces (-18%)
     ; 48ns compile (-17%) (-32%)
     ; 113ns + charser, memoized
     (title "Accept: TRANSIT")
-    (assert [:json "utf-8"] (m/negotiate-response m +transit-json-request+))
+    (assert (= ["application/transit+json" "utf-16"] (m/negotiate-response m +transit-json-request+)))
     (cc/quick-bench (m/negotiate-response m +transit-json-request+))))
 
 (defn request []
-  (let [formats (-> m/default-options m/no-decoding m/no-encoding m/create)]
+  (let [formats (m/create m/default-options)]
 
     ; 179ns
     ; 187ns (records)

--- a/test/muuntaja/core_test.clj
+++ b/test/muuntaja/core_test.clj
@@ -32,13 +32,9 @@
       (is (= "{\"kikka\":42}" (json-encoder data)))
       (is (= data (-> data json-encoder json-decoder)))
 
-      (testing "can't use invalid encoder /decoder"
-        (is (thrown?
-              Exception
-              (m/encoder m "application/INVALID")))
-        (is (thrown?
-              Exception
-              (m/decoder m "application/INVALID"))))))
+      (testing "invalid encoder /decoder returns nil"
+        (is (nil? (m/encoder m "application/INVALID")))
+        (is (nil? (m/decoder m "application/INVALID"))))))
 
   (testing "adding new format"
     (let [format "application/upper"

--- a/test/muuntaja/core_test.clj
+++ b/test/muuntaja/core_test.clj
@@ -36,14 +36,21 @@
       (is (= "OLIPA KERRAN AVARUUS" (encode data)))
       (is (= data (decode (encode data))))))
 
-  (testing "non-existing format throws exception"
+  (testing "setting non-existing format as default throws exception"
     (is (thrown?
           Exception
           (muuntaja/create
             (-> muuntaja/default-options
                 (assoc :default-format "kikka"))))))
 
-  (testing "overriding adapter configs"
+  (testing "selecting non-existing format as default throws exception"
+    (is (thrown?
+          Exception
+          (muuntaja/create
+            (-> muuntaja/default-options
+                (muuntaja/with-formats ["kikka"]))))))
+
+  (testing "overriding adapter options"
     (let [decode-json-kw (-> (muuntaja/create
                                (-> muuntaja/default-options))
                              (get-in [:adapters "application/json" :decode]))
@@ -52,4 +59,16 @@
                                 (muuntaja/with-decoder-opts "application/json" {:keywords? false})))
                           (get-in [:adapters "application/json" :decode]))]
       (is (= {:kikka true} (decode-json-kw "{\"kikka\":true}")))
-      (is (= {"kikka" true} (decode-json "{\"kikka\":true}"))))))
+      (is (= {"kikka" true} (decode-json "{\"kikka\":true}")))))
+
+  (testing "overriding invalid adapter options fails"
+    (is (thrown?
+          Exception
+          (muuntaja/create
+            (-> muuntaja/default-options
+                (muuntaja/with-decoder-opts "application/jsonz" {:keywords? false})))))
+    (is (thrown?
+          Exception
+          (muuntaja/create
+            (-> muuntaja/default-options
+                (muuntaja/with-encoder-opts "application/jsonz" {:keywords? false})))))))

--- a/test/muuntaja/core_test.clj
+++ b/test/muuntaja/core_test.clj
@@ -1,12 +1,12 @@
 (ns muuntaja.core-test
   (:require [clojure.test :refer :all]
-            [muuntaja.core :as muuntaja]
+            [muuntaja.core :as m]
             [clojure.string :as str]))
 
 (deftest core-test
 
   (testing "symmetic encode + decode for all formats"
-    (let [m (muuntaja/create muuntaja/default-options)
+    (let [m (m/create m/default-options)
           data {:kikka 42, :childs {:facts [1.2 true {:so "nested"}]}}]
       (are [format]
         (let [{:keys [encode decode]} (get-in m [:adapters format])]
@@ -19,17 +19,17 @@
         "application/transit+msgpack")))
 
   (testing "encode & decode"
-    (let [m (muuntaja/create muuntaja/default-options)
+    (let [m (m/create m/default-options)
           data {:kikka 42}]
-      (is (= "{\"kikka\":42}" (muuntaja/encode m "application/json" data)))
-      (is (= data (muuntaja/decode m "application/json" (muuntaja/encode m "application/json" data))))))
+      (is (= "{\"kikka\":42}" (m/encode m "application/json" data)))
+      (is (= data (m/decode m "application/json" (m/encode m "application/json" data))))))
 
   (testing "adding new format"
     (let [format "application/upper"
           upper-case-format {:decoder str/lower-case
                              :encoder str/upper-case}
-          m (muuntaja/create
-              (-> muuntaja/default-options
+          m (m/create
+              (-> m/default-options
                   (assoc-in [:formats format] upper-case-format)))
           {:keys [encode decode]} (get-in m [:adapters format])
           data "olipa kerran avaruus"]
@@ -39,24 +39,24 @@
   (testing "setting non-existing format as default throws exception"
     (is (thrown?
           Exception
-          (muuntaja/create
-            (-> muuntaja/default-options
+          (m/create
+            (-> m/default-options
                 (assoc :default-format "kikka"))))))
 
   (testing "selecting non-existing format as default throws exception"
     (is (thrown?
           Exception
-          (muuntaja/create
-            (-> muuntaja/default-options
-                (muuntaja/with-formats ["kikka"]))))))
+          (m/create
+            (-> m/default-options
+                (m/with-formats ["kikka"]))))))
 
   (testing "overriding adapter options"
-    (let [decode-json-kw (-> (muuntaja/create
-                               (-> muuntaja/default-options))
+    (let [decode-json-kw (-> (m/create
+                               (-> m/default-options))
                              (get-in [:adapters "application/json" :decode]))
-          decode-json (-> (muuntaja/create
-                            (-> muuntaja/default-options
-                                (muuntaja/with-decoder-opts "application/json" {:keywords? false})))
+          decode-json (-> (m/create
+                            (-> m/default-options
+                                (m/with-decoder-opts "application/json" {:keywords? false})))
                           (get-in [:adapters "application/json" :decode]))]
       (is (= {:kikka true} (decode-json-kw "{\"kikka\":true}")))
       (is (= {"kikka" true} (decode-json "{\"kikka\":true}")))))
@@ -64,11 +64,11 @@
   (testing "overriding invalid adapter options fails"
     (is (thrown?
           Exception
-          (muuntaja/create
-            (-> muuntaja/default-options
-                (muuntaja/with-decoder-opts "application/jsonz" {:keywords? false})))))
+          (m/create
+            (-> m/default-options
+                (m/with-decoder-opts "application/jsonz" {:keywords? false})))))
     (is (thrown?
           Exception
-          (muuntaja/create
-            (-> muuntaja/default-options
-                (muuntaja/with-encoder-opts "application/jsonz" {:keywords? false})))))))
+          (m/create
+            (-> m/default-options
+                (m/with-encoder-opts "application/jsonz" {:keywords? false})))))))

--- a/test/muuntaja/core_test.clj
+++ b/test/muuntaja/core_test.clj
@@ -24,6 +24,22 @@
       (is (= "{\"kikka\":42}" (m/encode m "application/json" data)))
       (is (= data (m/decode m "application/json" (m/encode m "application/json" data))))))
 
+  (testing "encoder & decoder"
+    (let [m (m/create m/default-options)
+          data {:kikka 42}
+          json-encoder (m/encoder m "application/json")
+          json-decoder (m/decoder m "application/json")]
+      (is (= "{\"kikka\":42}" (json-encoder data)))
+      (is (= data (-> data json-encoder json-decoder)))
+
+      (testing "can't use invalid encoder /decoder"
+        (is (thrown?
+              Exception
+              (m/encoder m "application/INVALID")))
+        (is (thrown?
+              Exception
+              (m/decoder m "application/INVALID"))))))
+
   (testing "adding new format"
     (let [format "application/upper"
           upper-case-format {:decoder str/lower-case

--- a/test/muuntaja/core_test.clj
+++ b/test/muuntaja/core_test.clj
@@ -11,22 +11,26 @@
       (are [format]
         (let [{:keys [encode decode]} (get-in m [:adapters format])]
           (= data (decode (encode data))))
-        :json :edn :yaml :msgpack :transit-json :transit-msgpack)))
+        "application/json"
+        "application/edn"
+        "application/x-yaml"
+        "application/msgpack"
+        "application/transit+json"
+        "application/transit+msgpack")))
 
   (testing "encode & decode"
     (let [m (muuntaja/create muuntaja/default-options)
           data {:kikka 42}]
-      (is (= "{\"kikka\":42}" (muuntaja/encode m :json data)))
-      (is (= data (muuntaja/decode m :json (muuntaja/encode m :json data))))))
+      (is (= "{\"kikka\":42}" (muuntaja/encode m "application/json" data)))
+      (is (= data (muuntaja/decode m "application/json" (muuntaja/encode m "application/json" data))))))
 
   (testing "adding new format"
-    (let [format :upper
+    (let [format "application/upper"
           upper-case-format {:decoder str/lower-case
                              :encoder str/upper-case}
           m (muuntaja/create
               (-> muuntaja/default-options
-                  (assoc-in [:adapters format] upper-case-format)
-                  (update :formats conj format)))
+                  (assoc-in [:formats format] upper-case-format)))
           {:keys [encode decode]} (get-in m [:adapters format])
           data "olipa kerran avaruus"]
       (is (= "OLIPA KERRAN AVARUUS" (encode data)))
@@ -37,15 +41,15 @@
           Exception
           (muuntaja/create
             (-> muuntaja/default-options
-                (update :formats conj :kikka))))))
+                (assoc :default-format "kikka"))))))
 
   (testing "overriding adapter configs"
     (let [decode-json-kw (-> (muuntaja/create
                                (-> muuntaja/default-options))
-                             (get-in [:adapters :json :decode]))
+                             (get-in [:adapters "application/json" :decode]))
           decode-json (-> (muuntaja/create
                             (-> muuntaja/default-options
-                                (muuntaja/with-decoder-opts :json {:keywords? false})))
-                          (get-in [:adapters :json :decode]))]
+                                (muuntaja/with-decoder-opts "application/json" {:keywords? false})))
+                          (get-in [:adapters "application/json" :decode]))]
       (is (= {:kikka true} (decode-json-kw "{\"kikka\":true}")))
       (is (= {"kikka" true} (decode-json "{\"kikka\":true}"))))))

--- a/test/muuntaja/middleware_test.clj
+++ b/test/muuntaja/middleware_test.clj
@@ -82,11 +82,11 @@
       (testing "forcing a content-type on a handler (bypass negotiate)"
         (let [echo-edn (fn [request]
                          {:status 200
-                          ::muuntaja/content-type "application/edn"
+                          ::m/content-type "application/edn"
                           :body (:body-params request)})
               app (middleware/wrap-format echo-edn)
               request (->request "application/json" "application/json" "{\"kikka\":42}")
               response (-> request app)]
           (is (= "{:kikka 42}" (:body response)))
-          (is (not (contains? response ::muuntaja/content-type)))
+          (is (not (contains? response ::m/content-type)))
           (is (= "application/edn; charset=utf-8" (get-in response [:headers "Content-Type"]))))))))

--- a/test/muuntaja/middleware_test.clj
+++ b/test/muuntaja/middleware_test.clj
@@ -1,6 +1,6 @@
 (ns muuntaja.middleware-test
   (:require [clojure.test :refer :all]
-            [muuntaja.core :as muuntaja]
+            [muuntaja.core :as m]
             [muuntaja.middleware :as middleware]))
 
 (defn echo [request]
@@ -13,11 +13,11 @@
    :body body})
 
 (deftest middleware-test
-  (let [m (muuntaja/create muuntaja/default-options)
+  (let [m (m/create m/default-options)
         data {:kikka 42}]
 
     (testing "multiple way to initialize the middleware"
-      (let [edn-string (muuntaja/encode m "application/edn" data)
+      (let [edn-string (m/encode m "application/edn" data)
             request (->request "application/edn" "application/edn" edn-string)]
         (is (= "{:kikka 42}" edn-string))
         (are [app]
@@ -27,7 +27,7 @@
           (middleware/wrap-format echo)
 
           ;; with default options
-          (middleware/wrap-format echo muuntaja/default-options)
+          (middleware/wrap-format echo m/default-options)
 
           ;; with compiled muuntaja
           (middleware/wrap-format echo m))))
@@ -37,8 +37,8 @@
 
         (testing "symmetric request decode + response encode"
           (are [format]
-            (let [payload (muuntaja/encode m format data)
-                  decode (partial muuntaja/decode m format)
+            (let [payload (m/encode m format data)
+                  decode (partial m/decode m format)
                   request (->request format format payload)]
               (= data (-> request app :body decode)))
             "application/json"
@@ -49,7 +49,7 @@
             "application/transit+msgpack"))
 
         (testing "content-type & accept"
-          (let [json-string (muuntaja/encode m "application/json" data)
+          (let [json-string (m/encode m "application/json" data)
                 call (fn [content-type accept]
                        (-> (->request content-type accept json-string) app :body))]
 
@@ -73,8 +73,8 @@
                 "application/schema+json")))
 
           (testing "different content-type & accept"
-            (let [edn-string (muuntaja/encode m "application/edn" data)
-                  yaml-string (muuntaja/encode m "application/x-yaml" data)
+            (let [edn-string (m/encode m "application/edn" data)
+                  yaml-string (m/encode m "application/x-yaml" data)
                   request (->request "application/edn" "application/x-yaml" edn-string)]
               (is (= yaml-string (-> request app :body))))))))
 

--- a/test/muuntaja/ring_json/json_test.clj
+++ b/test/muuntaja/ring_json/json_test.clj
@@ -20,7 +20,7 @@
        (middleware/wrap-format
          (-> muuntaja/default-options
              muuntaja/no-encoding
-             (muuntaja/with-decoder-opts :json (merge {:keywords? false} opts))))
+             (muuntaja/with-decoder-opts "application/json" (merge {:keywords? false} opts))))
        (middleware/wrap-exception (constantly
                                     (or
                                       (:malformed-response opts)
@@ -41,7 +41,7 @@
        (middleware/wrap-format
          (-> muuntaja/default-options
              muuntaja/no-decoding
-             (muuntaja/with-encoder-opts :json opts)))
+             (muuntaja/with-encoder-opts "application/json" opts)))
        (middleware/wrap-exception (constantly
                                     (or
                                       (:malformed-response opts)

--- a/test/muuntaja/ring_json/json_test.clj
+++ b/test/muuntaja/ring_json/json_test.clj
@@ -1,6 +1,6 @@
 (ns muuntaja.ring-json.json-test
   (:require [clojure.test :refer :all]
-            [muuntaja.core :as muuntaja]
+            [muuntaja.core :as m]
             [muuntaja.middleware :as middleware]
             [ring.util.io :refer [string-input-stream]]))
 
@@ -18,9 +18,9 @@
    (-> handler
        (middleware/wrap-params)
        (middleware/wrap-format
-         (-> muuntaja/default-options
-             muuntaja/no-encoding
-             (muuntaja/with-decoder-opts "application/json" (merge {:keywords? false} opts))))
+         (-> m/default-options
+             m/no-encoding
+             (m/with-decoder-opts "application/json" (merge {:keywords? false} opts))))
        (middleware/wrap-exception (constantly
                                     (or
                                       (:malformed-response opts)
@@ -39,9 +39,9 @@
   ([handler opts]
    (-> handler
        (middleware/wrap-format
-         (-> muuntaja/default-options
-             muuntaja/no-decoding
-             (muuntaja/with-encoder-opts "application/json" opts)))
+         (-> m/default-options
+             m/no-decoding
+             (m/with-encoder-opts "application/json" opts)))
        (middleware/wrap-exception (constantly
                                     (or
                                       (:malformed-response opts)

--- a/test/muuntaja/ring_middleware/format_params_test.clj
+++ b/test/muuntaja/ring_middleware/format_params_test.clj
@@ -5,7 +5,7 @@
             [clojure.walk :refer [stringify-keys keywordize-keys]]
             [msgpack.core :as msgpack]
             [clojure.string :as string]
-            [muuntaja.core :as muuntaja]
+            [muuntaja.core :as m]
             [muuntaja.middleware :as middleware])
   (:import [java.io ByteArrayInputStream ByteArrayOutputStream]))
 
@@ -14,11 +14,11 @@
 
 (defn wrap-api-params
   ([handler]
-   (wrap-api-params handler muuntaja/default-options))
+   (wrap-api-params handler m/default-options))
   ([handler opts]
    (-> handler
        (middleware/wrap-format
-         (-> opts muuntaja/no-encoding)))))
+         (-> opts m/no-encoding)))))
 
 (defn key-fn [s]
   (-> s (string/replace #"_" "-") keyword))
@@ -27,16 +27,16 @@
   (is (= {:foo-bar "bar"}
          (:body-params ((wrap-api-params
                           identity
-                          (-> muuntaja/default-options
-                              (muuntaja/with-formats ["application/json"])
-                              (muuntaja/with-decoder-opts "application/json" {:keywords? key-fn})))
+                          (-> m/default-options
+                              (m/with-formats ["application/json"])
+                              (m/with-decoder-opts "application/json" {:keywords? key-fn})))
                          {:headers {"content-type" "application/json"}
                           :body (stream "{\"foo_bar\":\"bar\"}")}))))
   (is (= {:foo-bar "bar"}
          (:body-params ((wrap-api-params
                           identity
-                          (-> muuntaja/default-options
-                              (muuntaja/with-decoder-opts "application/json" {:keywords? key-fn})))
+                          (-> m/default-options
+                              (m/with-decoder-opts "application/json" {:keywords? key-fn})))
                          {:headers {"content-type" "application/json"}
                           :body (stream "{\"foo_bar\":\"bar\"}")})))))
 
@@ -44,9 +44,9 @@
   (-> identity
       (middleware/wrap-params)
       (wrap-api-params
-        (-> muuntaja/default-options
-            (muuntaja/with-formats ["application/x-yaml"])
-            (muuntaja/with-decoder-opts "application/x-yaml" opts)))))
+        (-> m/default-options
+            (m/with-formats ["application/x-yaml"])
+            (m/with-decoder-opts "application/x-yaml" opts)))))
 
 (deftest augments-with-yaml-content-type
   (let [req {:headers {"content-type" "application/x-yaml; charset=UTF-8"}
@@ -60,9 +60,9 @@
   (-> identity
       (middleware/wrap-params)
       (wrap-api-params
-        (-> muuntaja/default-options
-            (muuntaja/with-formats ["application/x-yaml"])
-            (muuntaja/with-decoder-opts "application/x-yaml" {:keywords true})))))
+        (-> m/default-options
+            (m/with-formats ["application/x-yaml"])
+            (m/with-decoder-opts "application/x-yaml" {:keywords true})))))
 
 (deftest augments-with-yaml-kw-content-type
   (let [req {:headers {"content-type" "application/x-yaml; charset=UTF-8"}
@@ -76,9 +76,9 @@
   (-> identity
       (middleware/wrap-params)
       (wrap-api-params
-        (-> muuntaja/default-options
-            (muuntaja/with-formats ["application/msgpack"])
-            (muuntaja/with-decoder-opts "application/msgpack" {:keywords? false})))))
+        (-> m/default-options
+            (m/with-formats ["application/msgpack"])
+            (m/with-decoder-opts "application/msgpack" {:keywords? false})))))
 
 (deftest augments-with-msgpack-content-type
   (let [req {:headers {"content-type" "application/msgpack"}
@@ -92,8 +92,8 @@
   (-> identity
       (middleware/wrap-params)
       (wrap-api-params
-        (-> muuntaja/default-options
-            (muuntaja/with-formats ["application/msgpack"])))))
+        (-> m/default-options
+            (m/with-formats ["application/msgpack"])))))
 
 (deftest augments-with-msgpack-kw-content-type
   (let [req {:headers {"content-type" "application/msgpack"}
@@ -107,8 +107,8 @@
   (-> identity
       (middleware/wrap-params)
       (wrap-api-params
-        (-> muuntaja/default-options
-            (muuntaja/with-formats ["application/edn"])))))
+        (-> m/default-options
+            (m/with-formats ["application/edn"])))))
 
 (deftest augments-with-clojure-content-type
   (let [req {:headers {"content-type" "application/clojure; charset=UTF-8"}
@@ -157,8 +157,8 @@
   (-> identity
       (middleware/wrap-params)
       (wrap-api-params
-        (-> muuntaja/default-options
-            (muuntaja/with-formats ["application/transit+json"])))))
+        (-> m/default-options
+            (m/with-formats ["application/transit+json"])))))
 
 (deftest augments-with-transit-json-content-type
   (let [req {:headers {"content-type" "application/transit+json"}
@@ -172,8 +172,8 @@
   (-> identity
       (middleware/wrap-params)
       (wrap-api-params
-        (-> muuntaja/default-options
-            (muuntaja/with-formats ["application/transit+msgpack"])))))
+        (-> m/default-options
+            (m/with-formats ["application/transit+msgpack"])))))
 
 (deftest augments-with-transit-msgpack-content-type
   (let [req {:headers {"content-type" "application/transit+msgpack"}
@@ -243,8 +243,8 @@
                :headers {"content-type" content-type}}
           resp ((-> identity
                     (wrap-api-params
-                      (-> muuntaja/default-options
-                          (muuntaja/with-formats [format])))
+                      (-> m/default-options
+                          (m/with-formats [format])))
                     (middleware/wrap-exception (constantly {:status 999})))
                  req)]
       (= 999 (:status resp)))
@@ -262,9 +262,9 @@
   (-> identity
       (middleware/wrap-params)
       (wrap-api-params
-        (-> muuntaja/default-options
-            (muuntaja/with-formats ["application/transit+json"])
-            (muuntaja/with-decoder-opts "application/transit+json" {:handlers readers})))))
+        (-> m/default-options
+            (m/with-formats ["application/transit+json"])
+            (m/with-decoder-opts "application/transit+json" {:handlers readers})))))
 
 (def transit-body "[\"^ \", \"~:p\", [\"~#Point\",[1,2]]]")
 

--- a/test/muuntaja/ring_middleware/format_params_test.clj
+++ b/test/muuntaja/ring_middleware/format_params_test.clj
@@ -28,15 +28,15 @@
          (:body-params ((wrap-api-params
                           identity
                           (-> muuntaja/default-options
-                              (muuntaja/with-formats [:json])
-                              (muuntaja/with-decoder-opts :json {:keywords? key-fn})))
+                              (muuntaja/with-formats ["application/json"])
+                              (muuntaja/with-decoder-opts "application/json" {:keywords? key-fn})))
                          {:headers {"content-type" "application/json"}
                           :body (stream "{\"foo_bar\":\"bar\"}")}))))
   (is (= {:foo-bar "bar"}
          (:body-params ((wrap-api-params
                           identity
                           (-> muuntaja/default-options
-                              (muuntaja/with-decoder-opts :json {:keywords? key-fn})))
+                              (muuntaja/with-decoder-opts "application/json" {:keywords? key-fn})))
                          {:headers {"content-type" "application/json"}
                           :body (stream "{\"foo_bar\":\"bar\"}")})))))
 
@@ -45,8 +45,8 @@
       (middleware/wrap-params)
       (wrap-api-params
         (-> muuntaja/default-options
-            (muuntaja/with-formats [:yaml])
-            (muuntaja/with-decoder-opts :yaml opts)))))
+            (muuntaja/with-formats ["application/x-yaml"])
+            (muuntaja/with-decoder-opts "application/x-yaml" opts)))))
 
 (deftest augments-with-yaml-content-type
   (let [req {:headers {"content-type" "application/x-yaml; charset=UTF-8"}
@@ -61,8 +61,8 @@
       (middleware/wrap-params)
       (wrap-api-params
         (-> muuntaja/default-options
-            (muuntaja/with-formats [:yaml])
-            (muuntaja/with-decoder-opts :yaml {:keywords true})))))
+            (muuntaja/with-formats ["application/x-yaml"])
+            (muuntaja/with-decoder-opts "application/x-yaml" {:keywords true})))))
 
 (deftest augments-with-yaml-kw-content-type
   (let [req {:headers {"content-type" "application/x-yaml; charset=UTF-8"}
@@ -77,8 +77,8 @@
       (middleware/wrap-params)
       (wrap-api-params
         (-> muuntaja/default-options
-            (muuntaja/with-formats [:msgpack])
-            (muuntaja/with-decoder-opts :msgpack {:keywords? false})))))
+            (muuntaja/with-formats ["application/msgpack"])
+            (muuntaja/with-decoder-opts "application/msgpack" {:keywords? false})))))
 
 (deftest augments-with-msgpack-content-type
   (let [req {:headers {"content-type" "application/msgpack"}
@@ -93,7 +93,7 @@
       (middleware/wrap-params)
       (wrap-api-params
         (-> muuntaja/default-options
-            (muuntaja/with-formats [:msgpack])))))
+            (muuntaja/with-formats ["application/msgpack"])))))
 
 (deftest augments-with-msgpack-kw-content-type
   (let [req {:headers {"content-type" "application/msgpack"}
@@ -108,7 +108,7 @@
       (middleware/wrap-params)
       (wrap-api-params
         (-> muuntaja/default-options
-            (muuntaja/with-formats [:edn])))))
+            (muuntaja/with-formats ["application/edn"])))))
 
 (deftest augments-with-clojure-content-type
   (let [req {:headers {"content-type" "application/clojure; charset=UTF-8"}
@@ -158,7 +158,7 @@
       (middleware/wrap-params)
       (wrap-api-params
         (-> muuntaja/default-options
-            (muuntaja/with-formats [:transit-json])))))
+            (muuntaja/with-formats ["application/transit+json"])))))
 
 (deftest augments-with-transit-json-content-type
   (let [req {:headers {"content-type" "application/transit+json"}
@@ -173,7 +173,7 @@
       (middleware/wrap-params)
       (wrap-api-params
         (-> muuntaja/default-options
-            (muuntaja/with-formats [:transit-msgpack])))))
+            (muuntaja/with-formats ["application/transit+msgpack"])))))
 
 (deftest augments-with-transit-msgpack-content-type
   (let [req {:headers {"content-type" "application/transit+msgpack"}
@@ -244,12 +244,12 @@
           resp ((-> identity
                     (wrap-api-params
                       (-> muuntaja/default-options
-                          (assoc :formats [format])))
+                          (muuntaja/with-formats [format])))
                     (middleware/wrap-exception (constantly {:status 999})))
                  req)]
       (= 999 (:status resp)))
-    :json "application/json" "{:a 1}"
-    :edn "application/edn" "{\"a\": 1}"))
+    "application/json" "application/json" "{:a 1}"
+    "application/edn" "application/edn" "{\"a\": 1}"))
 
 ;; Transit options
 
@@ -263,8 +263,8 @@
       (middleware/wrap-params)
       (wrap-api-params
         (-> muuntaja/default-options
-            (muuntaja/with-formats [:transit-json])
-            (muuntaja/with-decoder-opts :transit-json {:handlers readers})))))
+            (muuntaja/with-formats ["application/transit+json"])
+            (muuntaja/with-decoder-opts "application/transit+json" {:handlers readers})))))
 
 (def transit-body "[\"^ \", \"~:p\", [\"~#Point\",[1,2]]]")
 

--- a/test/muuntaja/ring_middleware/format_response_test.clj
+++ b/test/muuntaja/ring_middleware/format_response_test.clj
@@ -51,8 +51,8 @@
         resp ((wrap-api-response
                 identity
                 (-> muuntaja/default-options
-                    (muuntaja/with-formats [:json])
-                    (muuntaja/with-encoder-opts :json {:pretty true}))) req)]
+                    (muuntaja/with-formats ["application/json"])
+                    (muuntaja/with-encoder-opts "application/json" {:pretty true}))) req)]
     (is (.contains (:body resp) "\n "))))
 
 #_(comment
@@ -88,7 +88,7 @@
   (wrap-api-response
     identity
     (-> muuntaja/default-options
-        (muuntaja/with-formats [:msgpack]))))
+        (muuntaja/with-formats ["application/msgpack"]))))
 
 (deftest format-msgpack-hashmap
   (let [body {:foo "bar"}
@@ -103,7 +103,7 @@
   (wrap-api-response
     identity
     (-> muuntaja/default-options
-        (muuntaja/with-formats [:edn]))))
+        (muuntaja/with-formats ["application/edn"]))))
 
 (deftest format-clojure-hashmap
   (let [body {:foo "bar"}
@@ -118,7 +118,7 @@
   (wrap-api-response
     identity
     (-> muuntaja/default-options
-        (muuntaja/with-formats [:yaml]))))
+        (muuntaja/with-formats ["application/x-yaml"]))))
 
 (deftest format-yaml-hashmap
   (let [body {:foo "bar"}
@@ -147,7 +147,7 @@
   (wrap-api-response
     identity
     (-> muuntaja/default-options
-        (muuntaja/with-formats [:transit-json]))))
+        (muuntaja/with-formats ["application/transit+json"]))))
 
 (deftest format-transit-json-hashmap
   (let [body {:foo "bar"}
@@ -162,7 +162,7 @@
   (wrap-api-response
     identity
     (-> muuntaja/default-options
-        (muuntaja/with-formats [:transit-msgpack]))))
+        (muuntaja/with-formats ["application/transit+msgpack"]))))
 
 (deftest format-transit-msgpack-hashmap
   (let [body {:foo "bar"}
@@ -272,9 +272,7 @@
   (wrap-api-response
     identity
     (-> muuntaja/default-options
-        (assoc-in [:adapters :foobar] {:format ["text/foo"]
-                                       :encoder (constantly "foobar")})
-        (assoc :formats [:foobar]))))
+        (assoc-in [:formats "text/foo"] {:encoder (constantly "foobar")}))))
 
 (deftest format-custom-api-hashmap
   (let [req {:body {:foo "bar"} :headers {"accept" "text/foo"}}
@@ -306,10 +304,7 @@
     (is (string? (:body resp-serialized)))))
 
 (def custom-encoder
-  (-> muuntaja/default-options
-      :adapters
-      :json
-      (assoc :format ["application/vnd.mixradio.something+json"])))
+  (get-in muuntaja/default-options [:formats "application/json"]))
 
 (def custom-content-type
   (wrap-api-response
@@ -317,8 +312,8 @@
       {:status 200
        :body {:foo "bar"}})
     (-> muuntaja/default-options
-        (assoc-in [:adapters :custom-json] custom-encoder)
-        (assoc :formats [:custom-json :json]))))
+        (assoc-in [:formats "application/vnd.mixradio.something+json"] custom-encoder)
+        (muuntaja/with-formats ["application/vnd.mixradio.something+json" "application/json"]))))
 
 (deftest custom-content-type-test
   (let [resp (custom-content-type {:body {:foo "bar"} :headers {"accept" "application/vnd.mixradio.something+json"}})]
@@ -335,14 +330,14 @@
   (wrap-api-response
     identity
     (-> muuntaja/default-options
-        (muuntaja/with-formats [:transit-json])
-        (muuntaja/with-encoder-opts :transit-json {:handlers writers}))))
+        (muuntaja/with-formats ["application/transit+json"])
+        (muuntaja/with-encoder-opts "application/transit+json" {:handlers writers}))))
 
 (def custom-api-transit-echo
   (wrap-api-response
     identity
     (-> muuntaja/default-options
-        (muuntaja/with-encoder-opts :transit-json {:handlers writers}))))
+        (muuntaja/with-encoder-opts "application/transit+json" {:handlers writers}))))
 
 (def transit-resp {:body (Point. 1 2)})
 

--- a/test/muuntaja/ring_middleware/format_response_test.clj
+++ b/test/muuntaja/ring_middleware/format_response_test.clj
@@ -1,6 +1,6 @@
 (ns muuntaja.ring-middleware.format-response-test
   (:require [clojure.test :refer :all]
-            [muuntaja.core :as muuntaja]
+            [muuntaja.core :as m]
             [muuntaja.middleware :as middleware]
             [cheshire.core :as json]
             [clj-yaml.core :as yaml]
@@ -15,11 +15,11 @@
 
 (defn wrap-api-response
   ([handler]
-   (wrap-api-response handler muuntaja/default-options))
+   (wrap-api-response handler m/default-options))
   ([handler opts]
    (-> handler
        (middleware/wrap-format
-         (-> opts muuntaja/no-decoding)))))
+         (-> opts m/no-decoding)))))
 
 (def api-echo
   (wrap-api-response identity))
@@ -50,9 +50,9 @@
         req {:body body}
         resp ((wrap-api-response
                 identity
-                (-> muuntaja/default-options
-                    (muuntaja/with-formats ["application/json"])
-                    (muuntaja/with-encoder-opts "application/json" {:pretty true}))) req)]
+                (-> m/default-options
+                    (m/with-formats ["application/json"])
+                    (m/with-encoder-opts "application/json" {:pretty true}))) req)]
     (is (.contains (:body resp) "\n "))))
 
 #_(comment
@@ -87,8 +87,8 @@
 (def msgpack-echo
   (wrap-api-response
     identity
-    (-> muuntaja/default-options
-        (muuntaja/with-formats ["application/msgpack"]))))
+    (-> m/default-options
+        (m/with-formats ["application/msgpack"]))))
 
 (deftest format-msgpack-hashmap
   (let [body {:foo "bar"}
@@ -102,8 +102,8 @@
 (def clojure-echo
   (wrap-api-response
     identity
-    (-> muuntaja/default-options
-        (muuntaja/with-formats ["application/edn"]))))
+    (-> m/default-options
+        (m/with-formats ["application/edn"]))))
 
 (deftest format-clojure-hashmap
   (let [body {:foo "bar"}
@@ -117,8 +117,8 @@
 (def yaml-echo
   (wrap-api-response
     identity
-    (-> muuntaja/default-options
-        (muuntaja/with-formats ["application/x-yaml"]))))
+    (-> m/default-options
+        (m/with-formats ["application/x-yaml"]))))
 
 (deftest format-yaml-hashmap
   (let [body {:foo "bar"}
@@ -146,8 +146,8 @@
 (def transit-json-echo
   (wrap-api-response
     identity
-    (-> muuntaja/default-options
-        (muuntaja/with-formats ["application/transit+json"]))))
+    (-> m/default-options
+        (m/with-formats ["application/transit+json"]))))
 
 (deftest format-transit-json-hashmap
   (let [body {:foo "bar"}
@@ -161,8 +161,8 @@
 (def transit-msgpack-echo
   (wrap-api-response
     identity
-    (-> muuntaja/default-options
-        (muuntaja/with-formats ["application/transit+msgpack"]))))
+    (-> m/default-options
+        (m/with-formats ["application/transit+msgpack"]))))
 
 (deftest format-transit-msgpack-hashmap
   (let [body {:foo "bar"}
@@ -271,7 +271,7 @@
 (def custom-api-echo
   (wrap-api-response
     identity
-    (-> muuntaja/default-options
+    (-> m/default-options
         (assoc-in [:formats "text/foo"] {:encoder (constantly "foobar")}))))
 
 (deftest format-custom-api-hashmap
@@ -293,7 +293,7 @@
 (def api-echo-pred
   (wrap-api-response
     identity
-    (-> muuntaja/default-options
+    (-> m/default-options
         (assoc :encode? ::serializable?))))
 
 (deftest custom-predicate
@@ -304,16 +304,16 @@
     (is (string? (:body resp-serialized)))))
 
 (def custom-encoder
-  (get-in muuntaja/default-options [:formats "application/json"]))
+  (get-in m/default-options [:formats "application/json"]))
 
 (def custom-content-type
   (wrap-api-response
     (fn [_]
       {:status 200
        :body {:foo "bar"}})
-    (-> muuntaja/default-options
+    (-> m/default-options
         (assoc-in [:formats "application/vnd.mixradio.something+json"] custom-encoder)
-        (muuntaja/with-formats ["application/vnd.mixradio.something+json" "application/json"]))))
+        (m/with-formats ["application/vnd.mixradio.something+json" "application/json"]))))
 
 (deftest custom-content-type-test
   (let [resp (custom-content-type {:body {:foo "bar"} :headers {"accept" "application/vnd.mixradio.something+json"}})]
@@ -329,15 +329,15 @@
 (def custom-transit-echo
   (wrap-api-response
     identity
-    (-> muuntaja/default-options
-        (muuntaja/with-formats ["application/transit+json"])
-        (muuntaja/with-encoder-opts "application/transit+json" {:handlers writers}))))
+    (-> m/default-options
+        (m/with-formats ["application/transit+json"])
+        (m/with-encoder-opts "application/transit+json" {:handlers writers}))))
 
 (def custom-api-transit-echo
   (wrap-api-response
     identity
-    (-> muuntaja/default-options
-        (muuntaja/with-encoder-opts "application/transit+json" {:handlers writers}))))
+    (-> m/default-options
+        (m/with-encoder-opts "application/transit+json" {:handlers writers}))))
 
 (def transit-resp {:body (Point. 1 2)})
 

--- a/test/muuntaja/ring_middleware/format_test.clj
+++ b/test/muuntaja/ring_middleware/format_test.clj
@@ -1,7 +1,7 @@
 (ns muuntaja.ring-middleware.format-test
   (:require [clojure.test :refer :all]
             [cheshire.core :as json]
-            [muuntaja.core :as muuntaja]
+            [muuntaja.core :as m]
             [muuntaja.middleware :as middleware]
             [clj-yaml.core :as yaml])
   (:import [java.io ByteArrayInputStream]))
@@ -24,8 +24,8 @@
          :body (:body-params req)})
       (middleware/wrap-params)
       (middleware/wrap-format
-        (-> muuntaja/default-options
-            (muuntaja/with-formats ["application/json"])))))
+        (-> m/default-options
+            (m/with-formats ["application/json"])))))
 
 (def api-echo-yaml
   (-> (fn [req]
@@ -34,8 +34,8 @@
          :body (:body-params req)})
       (middleware/wrap-params)
       (middleware/wrap-format
-        (-> muuntaja/default-options
-            (muuntaja/with-formats ["application/x-yaml"])))))
+        (-> m/default-options
+            (m/with-formats ["application/x-yaml"])))))
 
 (deftest test-api-round-trip
   (let [ok-accept "application/edn"

--- a/test/muuntaja/ring_middleware/format_test.clj
+++ b/test/muuntaja/ring_middleware/format_test.clj
@@ -25,7 +25,7 @@
       (middleware/wrap-params)
       (middleware/wrap-format
         (-> muuntaja/default-options
-            (assoc :formats [:json])))))
+            (muuntaja/with-formats ["application/json"])))))
 
 (def api-echo-yaml
   (-> (fn [req]
@@ -35,7 +35,7 @@
       (middleware/wrap-params)
       (middleware/wrap-format
         (-> muuntaja/default-options
-            (assoc :formats [:yaml])))))
+            (muuntaja/with-formats ["application/x-yaml"])))))
 
 (deftest test-api-round-trip
   (let [ok-accept "application/edn"


### PR DESCRIPTION
* remove type aliases (e.g. `:json`) from public apis, just content-types (e.g. `"application/json"`) now.
* add creation time runtime assertions for ill usage
* cleanup examples