### PR TITLE
Encode returns always a Stream

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,6 +15,7 @@
           :defaults {:doc/format :markdown}}
   :profiles {:dev {:jvm-opts ^:replace ["-server"]
                    :dependencies [[org.clojure/clojure "1.8.0"]
+                                  [ring/ring-core "1.6.0-beta6"]
                                   [ring-middleware-format "0.7.0"]
                                   [ring/ring-json "0.4.0"]
                                   [criterium "0.4.4"]]}

--- a/src/muuntaja/formats.clj
+++ b/src/muuntaja/formats.clj
@@ -38,6 +38,10 @@
   (fn [data]
     (ByteArrayInputStream. (.getBytes (json/generate-string data options)))))
 
+(defn make-json-string-encoder [options]
+  (fn [data]
+    (json/generate-string data options)))
+
 (defn make-streaming-json-encoder [options]
   (fn [data]
     (fn [stream]
@@ -99,6 +103,10 @@
     (ByteArrayInputStream.
       (.getBytes
         (pr-str data)))))
+
+(defn make-edn-string-encoder [_]
+  (fn [data]
+    (pr-str data)))
 
 (defprotocol EncodeEdn
   (encode-edn [this]))

--- a/src/muuntaja/formats.clj
+++ b/src/muuntaja/formats.clj
@@ -7,7 +7,7 @@
             [cognitect.transit :as transit]
             [msgpack.core :as msgpack]
             [clojure.java.io :as io])
-  (:import [java.io ByteArrayOutputStream DataInputStream DataOutputStream InputStreamReader PushbackReader InputStream ByteArrayInputStream]))
+  (:import [java.io ByteArrayOutputStream DataInputStream DataOutputStream InputStreamReader PushbackReader InputStream ByteArrayInputStream OutputStreamWriter]))
 
 (defn- slurp-to-bytes ^bytes [^InputStream in]
   (if in
@@ -35,7 +35,15 @@
           (json/parse-stream (InputStreamReader. x) keywords?))))))
 
 (defn make-json-encoder [options]
-  (fn [data] (json/generate-string data options)))
+  (fn [data]
+    (ByteArrayInputStream. (.getBytes (json/generate-string data options)))))
+
+(defn make-streaming-json-encoder [options]
+  (fn [data]
+    (fn [stream]
+      (let [writer (OutputStreamWriter. stream)]
+        (json/generate-stream data writer)
+        (.flush writer)))))
 
 (defprotocol EncodeJson
   (encode-json [this]))
@@ -70,7 +78,9 @@
 (defn make-yaml-encoder [options]
   (let [options-args (mapcat identity options)]
     (fn [data]
-      (apply yaml/generate-string data options-args))))
+      (ByteArrayInputStream.
+        (.getBytes
+          (apply yaml/generate-string data options-args))))))
 
 (defprotocol EncodeYaml
   (encode-yaml [this]))
@@ -86,7 +96,9 @@
 
 (defn make-edn-encoder [_]
   (fn [data]
-    (pr-str data)))
+    (ByteArrayInputStream.
+      (.getBytes
+        (pr-str data)))))
 
 (defprotocol EncodeEdn
   (encode-edn [this]))
@@ -99,17 +111,22 @@
     (let [reader (transit/reader in type options)]
       (transit/read reader))))
 
-(defn make-transit-encoder
+(defn make-transit-encoder [type {:keys [verbose] :as options}]
+  (let [full-type (if (and (= type :json) verbose) :json-verbose type)]
+    (fn [data]
+      (let [baos (ByteArrayOutputStream.)
+            writer (transit/writer baos full-type options)]
+        (transit/write writer data)
+        (ByteArrayInputStream.
+          (.toByteArray baos))))))
+
+(defn make-streaming-transit-encoder
   [type {:keys [verbose] :as options}]
-  (fn [data]
-    (let [out (ByteArrayOutputStream.)
-          full-type (if (and (= type :json) verbose)
-                      :json-verbose
-                      type)
-          wrt (transit/writer out full-type options)]
-      (transit/write wrt data)
-      (ByteArrayInputStream.
-        (.toByteArray out)))))
+  (let [full-type (if (and (= type :json) verbose) :json-verbose type)]
+    (fn [data]
+      (fn [stream]
+        (let [writer (transit/writer stream full-type options)]
+          (transit/write writer data))))))
 
 (defprotocol EncodeTransitJson
   (encode-transit-json [this]))

--- a/test/muuntaja/core_perf_test.clj
+++ b/test/muuntaja/core_perf_test.clj
@@ -194,21 +194,27 @@
 
   ; 2.9µs
   ; 2.5µs (no dynamic binding if not needed)
+  ; 1.8µs ???
   (title "muuntaja: parse-json-stream")
   (let [parse (m/decoder (m/create m/default-options) "application/json")
         request! (request-stream +json-request+)]
+    (assert (= {:kikka 42} (parse (:body (request!)))))
     (cc/quick-bench (parse (:body (request!)))))
 
   ; 2.5µs
+  ; 1.8µs ???
   (title "cheshire: parse-json-stream")
   (let [parse #(cheshire/parse-stream (InputStreamReader. %) true)
         request! (request-stream +json-request+)]
+    (assert (= {:kikka 42} (parse (:body (request!)))))
     (cc/quick-bench (parse (:body (request!)))))
 
   ; 5.1µs
+  ; 3.9µs ???
   (title "cheshire: parse-json-string")
   (let [parse #(cheshire/parse-string % true)
         request! (request-stream +json-request+)]
+    (assert (= {:kikka 42} (parse (slurp (:body (request!))))))
     (cc/quick-bench (parse (slurp (:body (request!)))))))
 
 (defn ring-middleware-format-e2e []
@@ -293,7 +299,7 @@
         request! (request-stream +json-request+)]
 
     (title "muuntaja: JSON-REQUEST-RESPONSE")
-    (assert (= (:body +json-request+) (:body (app (request!)))))
+    (assert (= (:body +json-request+) (slurp (:body (app (request!))))))
     (cc/quick-bench (app (request!))))
 
   ; 7.1µs
@@ -327,7 +333,7 @@
         request! (context-stream +json-request+)]
 
     (title "muuntaja: Interceptor JSON-REQUEST-RESPONSE")
-    (assert (= (:body +json-request+) (:body (app (request!)))))
+    (assert (= (:body +json-request+) (slurp (:body (app (request!))))))
     (cc/quick-bench (app (request!))))
 
   ; 7.5µs

--- a/test/muuntaja/core_test.clj
+++ b/test/muuntaja/core_test.clj
@@ -21,7 +21,7 @@
   (testing "encode & decode"
     (let [m (m/create m/default-options)
           data {:kikka 42}]
-      (is (= "{\"kikka\":42}" (m/encode m "application/json" data)))
+      (is (= "{\"kikka\":42}" (slurp (m/encode m "application/json" data))))
       (is (= data (m/decode m "application/json" (m/encode m "application/json" data))))))
 
   (testing "encoder & decoder"
@@ -29,7 +29,7 @@
           data {:kikka 42}
           json-encoder (m/encoder m "application/json")
           json-decoder (m/decoder m "application/json")]
-      (is (= "{\"kikka\":42}" (json-encoder data)))
+      (is (= "{\"kikka\":42}" (slurp (json-encoder data))))
       (is (= data (-> data json-encoder json-decoder)))
 
       (testing "invalid encoder /decoder returns nil"

--- a/test/muuntaja/formats_perf_test.clj
+++ b/test/muuntaja/formats_perf_test.clj
@@ -1,0 +1,186 @@
+(ns muuntaja.formats-perf-test
+  (:require [criterium.core :as cc]
+            [muuntaja.test_utils :refer :all]
+            [muuntaja.formats :as formats]
+            [muuntaja.json]
+            [ring.core.protocols :as protocols]
+            [clojure.java.io :as io])
+  (:import (java.io ByteArrayOutputStream ByteArrayInputStream)))
+
+;;
+;; start repl with `lein perf repl`
+;; perf measured with the following setup:
+;;
+;; Model Name:            MacBook Pro
+;; Model Identifier:      MacBookPro11,3
+;; Processor Name:        Intel Core i7
+;; Processor Speed:       2,5 GHz
+;; Number of Processors:  1
+;; Total Number of Cores: 4
+;; L2 Cache (per Core):   256 KB
+;; L3 Cache:              6 MB
+;; Memory:                16 GB
+;;
+
+(set! *warn-on-reflection* true)
+
+(def +data+ {:kikka 2})
+(def +json-string+ "{\"kikka\":2}")
+(def +transit-string+ "[\"^ \",\"~:kikka\",2]")
+(def +edn-string+ "{:kikka 2}")
+
+(defn ^ByteArrayOutputStream stream []
+  (ByteArrayOutputStream. 16384))
+
+(defn ring-write [data stream]
+  (protocols/write-body-to-stream
+    data
+    {:headers {"Content-Type" "application/json;charset=utf-8"}}
+    stream))
+
+(defn encode-json []
+  (let [encode0 (formats/make-json-string-encoder {})
+        encode1 (formats/make-streaming-json-encoder {})
+        encode2 (formats/make-json-encoder {})]
+
+    ;; 4.7µs
+    (title "json: string")
+    (let [call #(let [baos (stream)]
+                 (with-open [writer (io/writer baos)]
+                   (.write writer ^String (encode0 +data+)))
+                 baos)]
+
+      (assert (= +json-string+ (str (call))))
+      (cc/quick-bench
+        (call)))
+
+    ;; 3.1µs
+    (title "json: write-to-stream")
+    (let [call #(let [baos (stream)]
+                 ((encode1 +data+) baos)
+                 baos)]
+
+      (assert (= +json-string+ (str (call))))
+      (cc/quick-bench
+        (call)))
+
+    ;; 2.9µs
+    (title "json: inputstream")
+    (let [call #(let [baos (stream)
+                      is (encode2 +data+)]
+                 (io/copy is baos)
+                 baos)]
+
+      (assert (= +json-string+ (str (call))))
+      (cc/quick-bench
+        (call)))))
+
+(defn encode-json-ring []
+  (let [encode0 (formats/make-json-string-encoder {})
+        encode1 (formats/make-streaming-json-encoder {})
+        encode2 (formats/make-json-encoder {})]
+
+    ;; 8.1µs
+    (title "ring: json: string")
+    (let [call #(let [baos (stream)]
+                 (ring-write (encode0 +data+) baos)
+                 baos)]
+
+      (assert (= +json-string+ (str (call))))
+      (cc/quick-bench
+        (call)))
+
+    ;; 3.0µs
+    (title "ring: json: write-to-stream")
+    (let [call #(let [baos (stream)]
+                 (ring-write
+                   (reify
+                     protocols/StreamableResponseBody
+                     (write-body-to-stream [_ _ stream]
+                       ((encode1 +data+) stream)))
+                   baos)
+                 baos)]
+      (assert (= +json-string+ (str (call))))
+      (cc/quick-bench
+        (call)))
+
+    ;; 3.3µs
+    (title "ring: json: inputstream")
+    (let [call #(let [baos (stream)]
+                 (ring-write (encode2 +data+) baos)
+                 baos)]
+
+      (assert (= +json-string+ (str (call))))
+      (cc/quick-bench
+        (call)))
+
+    ;; 2.4µs
+    (title "ring: json: inputstream (muuntaja.json)")
+    (let [call #(let [baos (stream)]
+                 (ring-write
+                   (ByteArrayInputStream. (.getBytes (str (doto (muuntaja.json/object) (.put "kikka" 2)))))
+                   baos)
+                 baos)]
+
+      (assert (= +json-string+ (str (call))))
+      (cc/quick-bench
+        (call)))))
+
+(defn encode-transit-ring []
+  (let [encode1 (formats/make-streaming-transit-encoder :json {})
+        encode2 (formats/make-transit-encoder :json {})]
+
+    ;; 6.6µs
+    (title "ring: transit-json: write-to-stream")
+    (let [call #(let [baos (stream)]
+                 (ring-write
+                   (reify
+                     protocols/StreamableResponseBody
+                     (write-body-to-stream [_ _ stream]
+                       ((encode1 +data+) stream)))
+                   baos)
+                 baos)]
+
+      (assert (= +transit-string+ (str (call))))
+      (cc/quick-bench
+        (call)))
+
+    ;; 7.4µs
+    (title "ring: transit-json: inputstream")
+    (let [call #(let [baos (stream)]
+                 (ring-write (encode2 +data+) baos)
+                 baos)]
+
+      (assert (= +transit-string+ (str (call))))
+      (cc/quick-bench
+        (call)))))
+
+(defn encode-edn-ring []
+  (let [encode0 (formats/make-edn-string-encoder {})
+        encode2 (formats/make-edn-encoder {})]
+
+    ;; 8.8µs
+    (title "ring: edn: string")
+    (let [call #(let [baos (stream)]
+                 (ring-write (encode0 +data+) baos)
+                 baos)]
+
+      (assert (= +edn-string+ (str (call))))
+      (cc/quick-bench
+        (call)))
+
+    ;; 4.4µs
+    (title "ring: edn: inputstream")
+    (let [call #(let [baos (stream)]
+                 (ring-write (encode2 +data+) baos)
+                 baos)]
+
+      (assert (= +edn-string+ (str (call))))
+      (cc/quick-bench
+        (call)))))
+
+(comment
+  (encode-json)
+  (encode-json-ring)
+  (encode-transit-ring)
+  (encode-edn-ring))

--- a/test/muuntaja/middleware_test.clj
+++ b/test/muuntaja/middleware_test.clj
@@ -17,11 +17,11 @@
         data {:kikka 42}]
 
     (testing "multiple way to initialize the middleware"
-      (let [edn-string (m/encode m "application/edn" data)
+      (let [edn-string (slurp (m/encode m "application/edn" data))
             request (->request "application/edn" "application/edn" edn-string)]
         (is (= "{:kikka 42}" edn-string))
         (are [app]
-          (= edn-string (:body (app request)))
+          (= edn-string (slurp (:body (app request))))
 
           ;; without paramters
           (middleware/wrap-format echo)
@@ -49,9 +49,9 @@
             "application/transit+msgpack"))
 
         (testing "content-type & accept"
-          (let [json-string (m/encode m "application/json" data)
+          (let [json-string (slurp (m/encode m "application/json" data))
                 call (fn [content-type accept]
-                       (-> (->request content-type accept json-string) app :body))]
+                       (some-> (->request content-type accept json-string) app :body slurp))]
 
             (is (= "{\"kikka\":42}" json-string))
 
@@ -73,10 +73,10 @@
                 "application/schema+json")))
 
           (testing "different content-type & accept"
-            (let [edn-string (m/encode m "application/edn" data)
-                  yaml-string (m/encode m "application/x-yaml" data)
+            (let [edn-string (slurp (m/encode m "application/edn" data))
+                  yaml-string (slurp (m/encode m "application/x-yaml" data))
                   request (->request "application/edn" "application/x-yaml" edn-string)]
-              (is (= yaml-string (-> request app :body))))))))
+              (is (= yaml-string (some-> request app :body slurp))))))))
 
     (testing "runtime options for encoding & decoding"
       (testing "forcing a content-type on a handler (bypass negotiate)"
@@ -87,6 +87,6 @@
               app (middleware/wrap-format echo-edn)
               request (->request "application/json" "application/json" "{\"kikka\":42}")
               response (-> request app)]
-          (is (= "{:kikka 42}" (:body response)))
+          (is (= "{:kikka 42}" (-> response :body slurp)))
           (is (not (contains? response ::m/content-type)))
           (is (= "application/edn; charset=utf-8" (get-in response [:headers "Content-Type"]))))))))

--- a/test/muuntaja/ring_json/json_test.clj
+++ b/test/muuntaja/ring_json/json_test.clj
@@ -203,9 +203,10 @@
 (deftest test-json-response
   (testing "map body"
     (let [handler (constantly {:status 200 :headers {} :body {:foo "bar"}})
-          response ((wrap-json-response handler) {})]
+          response ((wrap-json-response handler) {})
+          body (-> response :body slurp)]
       (is (= (get-in response [:headers "Content-Type"]) "application/json; charset=utf-8"))
-      (is (= (:body response) "{\"foo\":\"bar\"}"))))
+      (is (= body "{\"foo\":\"bar\"}"))))
 
   (testing "string body"
     (let [handler (constantly {:status 200 :headers {} :body "foobar"})
@@ -215,31 +216,36 @@
 
   (testing "vector body"
     (let [handler (constantly {:status 200 :headers {} :body [:foo :bar]})
-          response ((wrap-json-response handler) {})]
+          response ((wrap-json-response handler) {})
+          body (-> response :body slurp)]
       (is (= (get-in response [:headers "Content-Type"]) "application/json; charset=utf-8"))
-      (is (= (:body response) "[\"foo\",\"bar\"]"))))
+      (is (= body "[\"foo\",\"bar\"]"))))
 
   (testing "list body"
     (let [handler (constantly {:status 200 :headers {} :body '(:foo :bar)})
-          response ((wrap-json-response handler) {})]
+          response ((wrap-json-response handler) {})
+          body (-> response :body slurp)]
       (is (= (get-in response [:headers "Content-Type"]) "application/json; charset=utf-8"))
-      (is (= (:body response) "[\"foo\",\"bar\"]"))))
+      (is (= body "[\"foo\",\"bar\"]"))))
 
   (testing "set body"
     (let [handler (constantly {:status 200 :headers {} :body #{:foo :bar}})
-          response ((wrap-json-response handler) {})]
+          response ((wrap-json-response handler) {})
+          body (-> response :body slurp)]
       (is (= (get-in response [:headers "Content-Type"]) "application/json; charset=utf-8"))
-      (is (or (= (:body response) "[\"foo\",\"bar\"]")
-              (= (:body response) "[\"bar\",\"foo\"]")))))
+      (is (or (= body "[\"foo\",\"bar\"]")
+              (= body "[\"bar\",\"foo\"]")))))
 
   (testing "JSON options"
     (let [handler (constantly {:status 200 :headers {} :body {:foo "bar" :baz "quz"}})
-          response ((wrap-json-response handler {:pretty true}) {})]
-      (is (or (= (:body response) "{\n  \"foo\" : \"bar\",\n  \"baz\" : \"quz\"\n}")
-              (= (:body response) "{\n  \"baz\" : \"quz\",\n  \"foo\" : \"bar\"\n}")))))
+          response ((wrap-json-response handler {:pretty true}) {})
+          body (-> response :body slurp)]
+      (is (or (= body "{\n  \"foo\" : \"bar\",\n  \"baz\" : \"quz\"\n}")
+              (= body "{\n  \"baz\" : \"quz\",\n  \"foo\" : \"bar\"\n}")))))
 
   (testing "don’t overwrite Content-Type if already set"
     (let [handler (constantly {:status 200 :headers {"Content-Type" "application/json; some-param=some-value"} :body {:foo "bar"}})
-          response ((wrap-json-response handler) {})]
+          response ((wrap-json-response handler) {})
+          body (-> response :body slurp)]
       (is (= (get-in response [:headers "Content-Type"]) "application/json; some-param=some-value"))
-      (is (= (:body response) "{\"foo\":\"bar\"}")))))
+      (is (= body "{\"foo\":\"bar\"}")))))

--- a/test/muuntaja/ring_middleware/format_test.clj
+++ b/test/muuntaja/ring_middleware/format_test.clj
@@ -45,7 +45,7 @@
                           :body (stream (pr-str msg))})]
     (is (= (get-in r-trip [:headers "Content-Type"])
            "application/edn; charset=utf-8"))
-    (is (= (read-string (:body r-trip)) msg))
+    (is (= (read-string (slurp (:body r-trip))) msg))
     (is (= (:params r-trip) msg))
     (is (.contains (get-in (api-echo {:headers {"accept" "foo/bar"
                                                 "content-type" ok-accept}
@@ -61,7 +61,7 @@
         r-trip (api-echo-json ok-req)]
     (is (= (get-in r-trip [:headers "Content-Type"])
            "application/json; charset=utf-8"))
-    (is (= (json/decode (:body r-trip)) msg))
+    (is (= (json/decode (slurp (:body r-trip))) msg))
     (is (= (:params r-trip) {:test "ok"}))
     (is (.contains (get-in (api-echo-json
                              {:headers {"accept" "application/edn"


### PR DESCRIPTION
Instead of returning JSON, YAML or EDN String, all encode-functions return now an InputStream. Added tests to verify that via `ring.core.protocols.StreamableResponseBody`, stream handling is much more efficient (2-3 better perf). Also, enables the response charset to be set.