### PR TITLE
Separate negotiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,10 +165,10 @@ Full [API documentation](http://metosin.github.com/muuntaja) is available.
 
 * `:muuntaja.core/format`, format name that was used to decode the request body, e.g. `application/json`. If
    the key is already present in the request map, muuntaja middleware/interceptor will skip the decoding process.
-* `:muuntaja.core/accept`, client-negotiated format name for the response, e.g. `application/json`. Will
-   be used later in the response pipeline.
-* `:muuntaja.core/accept-charset`, client-negotiated charset for the response, e.g. `utf-8`. Will
-   be used later in the response pipeline.
+* `:muuntaja.core/request`, client-negotiated request format and charset as `muuntaja.core/FormatAndCharset` record. Will
+be used in the response pipeline.
+* `:muuntaja.core/response`, client-negotiated response format and charset as `muuntaja.core/FormatAndCharset` record. Will
+be used in the response pipeline.
 * `:body-params` decoded body is here.
 
 ### Response
@@ -185,6 +185,8 @@ Full [API documentation](http://metosin.github.com/muuntaja) is available.
 {:extract-content-type-fn extract-content-type-ring
  :extract-accept-charset-fn extract-accept-charset-ring
  :extract-accept-fn extract-accept-ring
+
+ :on-request-decode-exception on-request-decode-exception
 
  :decode? (constantly true)
  :encode? encode-collections-with-override

--- a/src/muuntaja/formats.clj
+++ b/src/muuntaja/formats.clj
@@ -2,7 +2,7 @@
   (:require [cheshire.core :as json]
             [cheshire.parse :as parse]
             [clj-yaml.core :as yaml]
-            [clojure.tools.reader.edn :as edn]
+            [clojure.edn :as edn]
             [clojure.walk :as walk]
             [cognitect.transit :as transit]
             [msgpack.core :as msgpack]

--- a/src/muuntaja/middleware.clj
+++ b/src/muuntaja/middleware.clj
@@ -51,9 +51,9 @@
 ;; separate mw for negotiate, request & response
 ;;
 
-(defn wrap-request-format
+(defn wrap-format-request
   ([handler]
-   (wrap-request-format handler m/default-options))
+   (wrap-format-request handler m/default-options))
   ([handler options-or-formats]
    (let [formats (if (instance? Formats options-or-formats)
                    options-or-formats
@@ -64,9 +64,9 @@
        ([request respond raise]
         (handler (m/format-request formats request) respond raise))))))
 
-(defn wrap-negotiate-format
+(defn wrap-format-negotiate
   ([handler]
-   (wrap-negotiate-format handler m/default-options))
+   (wrap-format-negotiate handler m/default-options))
   ([handler options-or-formats]
    (let [formats (if (instance? Formats options-or-formats)
                    options-or-formats
@@ -77,9 +77,9 @@
        ([request respond raise]
         (handler (m/negotiate-ring-request formats request) respond raise))))))
 
-(defn wrap-response-format
+(defn wrap-format-response
   ([handler]
-   (wrap-response-format handler m/default-options))
+   (wrap-format-response handler m/default-options))
   ([handler options-or-formats]
    (let [formats (if (instance? Formats options-or-formats)
                    options-or-formats

--- a/src/muuntaja/middleware.clj
+++ b/src/muuntaja/middleware.clj
@@ -46,3 +46,46 @@
        ([request respond raise]
         (let [req (m/format-request formats request)]
           (handler req #(respond (m/format-response formats req %)) raise)))))))
+
+;;
+;; separate mw for negotiate, request & response
+;;
+
+(defn wrap-request-format
+  ([handler]
+   (wrap-request-format handler m/default-options))
+  ([handler options-or-formats]
+   (let [formats (if (instance? Formats options-or-formats)
+                   options-or-formats
+                   (m/create options-or-formats))]
+     (fn
+       ([request]
+        (handler (m/decode-ring-request formats request)))
+       ([request respond raise]
+        (handler (m/format-request formats request) respond raise))))))
+
+(defn wrap-negotiate-format
+  ([handler]
+   (wrap-negotiate-format handler m/default-options))
+  ([handler options-or-formats]
+   (let [formats (if (instance? Formats options-or-formats)
+                   options-or-formats
+                   (m/create options-or-formats))]
+     (fn
+       ([request]
+        (handler (m/negotiate-ring-request formats request)))
+       ([request respond raise]
+        (handler (m/negotiate-ring-request formats request) respond raise))))))
+
+(defn wrap-response-format
+  ([handler]
+   (wrap-response-format handler m/default-options))
+  ([handler options-or-formats]
+   (let [formats (if (instance? Formats options-or-formats)
+                   options-or-formats
+                   (m/create options-or-formats))]
+     (fn
+       ([request]
+        (->> (handler request) (m/format-response formats request)))
+       ([request respond raise]
+        (handler request #(respond (m/format-response formats request %)) raise))))))

--- a/test/muuntaja/middleware_test.clj
+++ b/test/muuntaja/middleware_test.clj
@@ -1,7 +1,8 @@
 (ns muuntaja.middleware-test
   (:require [clojure.test :refer :all]
             [muuntaja.core :as m]
-            [muuntaja.middleware :as middleware]))
+            [muuntaja.middleware :as middleware]
+            [muuntaja.core]))
 
 (defn echo [request]
   {:status 200
@@ -32,7 +33,25 @@
           (middleware/wrap-format echo m/default-options)
 
           ;; with compiled muuntaja
-          (middleware/wrap-format echo m))))
+          (middleware/wrap-format echo m)
+
+          ;; without paramters
+          (-> echo
+              (middleware/wrap-request-format)
+              (middleware/wrap-response-format)
+              (middleware/wrap-negotiate-format))
+
+          ;; with default options
+          (-> echo
+              (middleware/wrap-request-format m/default-options)
+              (middleware/wrap-response-format m/default-options)
+              (middleware/wrap-negotiate-format m/default-options))
+
+          ;; with compiled muuntaja
+          (-> echo
+              (middleware/wrap-request-format m)
+              (middleware/wrap-response-format m)
+              (middleware/wrap-negotiate-format m)))))
 
     (testing "with defaults"
       (let [app (middleware/wrap-format echo)]

--- a/test/muuntaja/middleware_test.clj
+++ b/test/muuntaja/middleware_test.clj
@@ -37,21 +37,21 @@
 
           ;; without paramters
           (-> echo
-              (middleware/wrap-request-format)
-              (middleware/wrap-response-format)
-              (middleware/wrap-negotiate-format))
+              (middleware/wrap-format-request)
+              (middleware/wrap-format-response)
+              (middleware/wrap-format-negotiate))
 
           ;; with default options
           (-> echo
-              (middleware/wrap-request-format m/default-options)
-              (middleware/wrap-response-format m/default-options)
-              (middleware/wrap-negotiate-format m/default-options))
+              (middleware/wrap-format-request m/default-options)
+              (middleware/wrap-format-response m/default-options)
+              (middleware/wrap-format-negotiate m/default-options))
 
           ;; with compiled muuntaja
           (-> echo
-              (middleware/wrap-request-format m)
-              (middleware/wrap-response-format m)
-              (middleware/wrap-negotiate-format m)))))
+              (middleware/wrap-format-request m)
+              (middleware/wrap-format-response m)
+              (middleware/wrap-format-negotiate m)))))
 
     (testing "with defaults"
       (let [app (middleware/wrap-format echo)]


### PR DESCRIPTION
Started to integrate into compojure.api. Noticed that the encode & decode can't be done in the same steps if one want's to do the exception handling in a central place:

* if a request parsing fails, an exception is thrown (and caught in a separate mw). How does this mw know how to render the format exception in the negotiated format?

* solution: separate negotiation from request decode. New mws to enable running those in separate stages:

```clj

;; with defaults
(def m (m/create))

;; still works, bundles all together
(-> app (middleware/wrap-format m))

;; can be run as separate steps
(-> app
    (middleware/wrap-format-request m)
    (middleware/wrap-format-response m)
    (middleware/wrap-format-negotiate m))
``` 