### PR TITLE
optionally allow empty input on decode, fixes #33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.2.0-SNAPSHOT (10.3.2017)
 
+* New option to allow empty input on decode, `:allow-empty-input?` (default to `false`). If set to `true`, empty inputstreams map to `nil` body, otherwise, the decoder decides what happens (transit fails on default).
+  * Fixes [#33](https://github.com/metosin/muuntaja/issues/33)
+
 * **BREAKING**: by default, `application/msgpack` and `application/x-yaml` are not used (smaller core)
   * new helpers to add formats (need to add the deps manually):
     * `application/yaml`: `[circleci/clj-yaml "0.5.5"]`

--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ be used in the response pipeline.
         :decode-request-body? (constantly true)
         :encode-reseponse-body? encode-collections-with-override}
 
+ :allow-empty-input? false
+
  :default-charset "utf-8"
  :charsets muuntaja/available-charsets
 

--- a/src/clj/muuntaja/protocols.clj
+++ b/src/clj/muuntaja/protocols.clj
@@ -43,7 +43,7 @@
   (.write w (str "<<StreamableResponse>>")))
 
 (defprotocol AsInputStream
-  (as-input-stream [this]))
+  (as-input-stream ^java.io.InputStream [this]))
 
 (extend-protocol AsInputStream
   InputStream

--- a/test/muuntaja/core_test.clj
+++ b/test/muuntaja/core_test.clj
@@ -63,6 +63,16 @@
         "UTF-16"
         (is (= "UTF-16" (str (Charset/defaultCharset)))))))
 
+  (testing "on empty input"
+    (testing "by default - exception is thrown"
+      (let [m (m/create)
+            in (ByteArrayInputStream. (byte-array 0))]
+        (is (thrown? Exception (m/decode m "application/transit+json" in)))))
+    (testing "optionally nil is returned"
+      (let [m (m/create (assoc m/default-options :allow-empty-input? true))
+            in (ByteArrayInputStream. (byte-array 0))]
+        (is (nil? (m/decode m "application/transit+json" in))))))
+
   ;; TODO: should these behave in same way?
   (testing "decode with empty input"
     (let [no-data (fn [] (ByteArrayInputStream. (byte-array 0)))]


### PR DESCRIPTION
is the option name good? Should be something more explicit?

* `:allow-empty-input?`
* `:allow-empty-body-on-decode?`
* `:allow-nil-on-decode?`

