### PR TITLE
Handle nil-input (fixes #41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## UNRELEASED
 
 * **BREAKING**: Handling empty responses
-  * `:allow-empty-input-on-decode?` is now called `:allow-empty-input`, defaulting to `true`
-  * by default, empty input(streams) is decoded into`nil`
-  * setting the value to `false` with cause the decoder to do whatever it does
+  * `:allow-empty-input-on-decode?` is now called `:allow-empty-input?`. It's a boolean:
+    * `true` (default): empty input(stream) is decoded into `nil`
+    * `false` with cause the decoder to do whatever it does (e.g. Transit fails, Cheshire returns `nil`)
 
 * updated deps:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## UNRELEASED
+
+* `nil` input is always resolved as `nil`. Fixes [#41](https://github.com/metosin/muuntaja/issues/41)
+* updated deps:
+
+```clj
+[cheshire "5.7.1"] is available but we use "5.7.0"
+```
+
 ## 0.2.1 (2.4.2017)
 
 * removed direct dependencies to msgpack, fixes [#39](https://github.com/metosin/muuntaja/issues/39).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## UNRELEASED
 
-* `nil` input is always resolved as `nil`. Fixes [#41](https://github.com/metosin/muuntaja/issues/41)
+* **BREAKING**: Handling empty responses
+  * `:allow-empty-input-on-decode?` is now called `:allow-empty-input`, defaulting to `true`
+  * by default, empty input(streams) is decoded into`nil`
+  * setting the value to `false` with cause the decoder to do whatever it does
+
 * updated deps:
 
 ```clj

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ be used in the response pipeline.
         :decode-request-body? (constantly true)
         :encode-reseponse-body? encode-collections-with-override}
 
- :allow-empty-input-on-decode? false
+ :allow-empty-input? true
 
  :default-charset "utf-8"
  :charsets muuntaja/available-charsets

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
   :source-paths ["src/clj"]
   :javac-options ["-Xlint:unchecked"]
   :java-source-paths ["src/java"]
-  :dependencies [[cheshire "5.7.0" :exclusions [com.fasterxml.jackson.core/jackson-core]]
+  :dependencies [[cheshire "5.7.1" :exclusions [com.fasterxml.jackson.core/jackson-core]]
                  [com.fasterxml.jackson.core/jackson-databind "2.8.7"]
                  [com.cognitect/transit-clj "0.8.300"]]
   :plugins [[lein-codox "0.10.3"]]
@@ -17,7 +17,7 @@
           :defaults {:doc/format :markdown}}
   :profiles {:dev {:jvm-opts ^:replace ["-server"]
                    :dependencies [[org.clojure/clojure "1.8.0"]
-                                  [ring/ring-core "1.6.0-RC1"]
+                                  [ring/ring-core "1.6.0"]
                                   [ring-middleware-format "0.7.2"]
                                   [ring-transit "0.1.6"]
                                   [ring/ring-json "0.4.0"]

--- a/src/clj/muuntaja/core.clj
+++ b/src/clj/muuntaja/core.clj
@@ -132,6 +132,9 @@
           (str "Invalid default format " default-format)
           {:formats valid-format?
            :default-format default-format})))
+    (assert
+      (not (:allow-empty-input-on-decode? options))
+      ":allow-empty-input-on-decode? is deprecated in Muuntaja 0.3.0")
     (->
       (merge
         (dissoc options :formats)

--- a/src/clj/muuntaja/core.clj
+++ b/src/clj/muuntaja/core.clj
@@ -83,8 +83,7 @@
                 (if (and allow-empty-input? decode?)
                   (fn [^InputStream is charset]
                     (if (pos? (.available is)) ($ is charset)))
-                  (fn [^InputStream is charset]
-                    ($ is charset))))
+                  $))
         prepare (if decode? protocols/as-input-stream identity)]
     (if (and p pf)
       (fn f

--- a/src/clj/muuntaja/core.clj
+++ b/src/clj/muuntaja/core.clj
@@ -82,8 +82,9 @@
                 ;; optional guard on empty imput
                 (if (and allow-empty-input-on-decode? decode?)
                   (fn [^InputStream is charset]
-                    (if (pos? (.available is)) ($ is charset)))
-                  $))
+                    (if (and (not (nil? is)) (pos? (.available is))) ($ is charset)))
+                  (fn [^InputStream is charset]
+                    (if-not (nil? is) ($ is charset)))))
         prepare (if decode? protocols/as-input-stream identity)]
     (if (and p pf)
       (fn f

--- a/src/clj/muuntaja/protocols.clj
+++ b/src/clj/muuntaja/protocols.clj
@@ -55,4 +55,8 @@
 
   String
   (as-input-stream [this]
-    (ByteArrayInputStream. (.getBytes this "utf-8"))))
+    (ByteArrayInputStream. (.getBytes this "utf-8")))
+
+  nil
+  (as-input-stream [_]
+    nil))

--- a/src/clj/muuntaja/protocols.clj
+++ b/src/clj/muuntaja/protocols.clj
@@ -59,4 +59,4 @@
 
   nil
   (as-input-stream [_]
-    nil))
+    (ByteArrayInputStream. (byte-array 0))))

--- a/test/muuntaja/core_test.clj
+++ b/test/muuntaja/core_test.clj
@@ -225,3 +225,8 @@
                 (assoc-in
                   [:formats "application/jsonz" :decoder-opts]
                   {:keywords? false})))))))
+
+(deftest migration-to-0.3.0-test
+  (is (thrown?
+        AssertionError
+        (m/create (assoc m/default-options :allow-empty-input-on-decode? true)))))

--- a/test/muuntaja/core_test.clj
+++ b/test/muuntaja/core_test.clj
@@ -71,11 +71,15 @@
                    (yaml-format/with-yaml-format)
                    (assoc :allow-empty-input-on-decode? true)))]
 
-      (testing "by default - exception is thrown"
+      (testing "by default - exception is thrown for empty stream"
         (is (thrown? Exception (m/decode m "application/transit+json" (empty)))))
 
-      (testing "optionally nil is returned"
-        (is (nil? (m/decode m2 "application/transit+json" (empty)))))
+      (testing "by default - nil input returns nil stream"
+        (is (nil? (m/decode m "application/transit+json" nil))))
+
+      (testing "optionally nil is returned in both cases"
+        (is (nil? (m/decode m2 "application/transit+json" (empty))))
+        (is (nil? (m/decode m2 "application/transit+json" nil))))
 
       (testing "all formats"
         (testing "with defaults"

--- a/test/muuntaja/core_test.clj
+++ b/test/muuntaja/core_test.clj
@@ -69,39 +69,39 @@
                (-> m/default-options
                    (msgpack-format/with-msgpack-format)
                    (yaml-format/with-yaml-format)
-                   (assoc :allow-empty-input-on-decode? true)))]
+                   (assoc :allow-empty-input? false)))]
 
-      (testing "by default - exception is thrown for empty stream"
-        (is (thrown? Exception (m/decode m "application/transit+json" (empty)))))
+      (testing "by default - nil is returned for empty stream"
+        (is (nil? (m/decode m "application/transit+json" (empty)))))
 
       (testing "by default - nil input returns nil stream"
         (is (nil? (m/decode m "application/transit+json" nil))))
 
-      (testing "optionally nil is returned in both cases"
-        (is (nil? (m/decode m2 "application/transit+json" (empty))))
-        (is (nil? (m/decode m2 "application/transit+json" nil))))
+      (testing "optionally decoder can decide to throw"
+        (is (thrown? Exception (m/decode m2 "application/transit+json" (empty))))
+        (is (thrown? Exception (m/decode m2 "application/transit+json" nil))))
 
       (testing "all formats"
-        (testing "with defaults"
+        (testing "with :allow-empty-input? false"
 
           (testing "json & yaml return nil"
             (are [format]
-              (= nil (m/decode m format (empty)))
+              (= nil (m/decode m2 format (empty)))
               "application/json"
               "application/x-yaml"))
 
           (testing "others fail"
             (are [format]
-              (thrown-with-msg? Exception #"Malformed" (m/decode m format (empty)))
+              (thrown-with-msg? Exception #"Malformed" (m/decode m2 format (empty)))
               "application/edn"
               "application/msgpack"
               "application/transit+json"
               "application/transit+msgpack")))
 
-        (testing "with :allow-empty-input-on-decode? true"
+        (testing "with defaults"
           (testing "all formats return nil"
             (are [format]
-              (= nil (m/decode m2 format (empty)))
+              (= nil (m/decode m format (empty)))
               "application/json"
               "application/edn"
               "application/x-yaml"


### PR DESCRIPTION
Safe-guard for `nil` input(stream) in all cases.