### PR TITLE
Disable manual encoding of record by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.3.0-SNAPSHOT
 
+* **BREAKING**: Drop default support for manual encoding of records.
+  * Guide how to enable it in the wiki: https://github.com/metosin/muuntaja/wiki/Configuration#manual-encoding
+
 * **BREAKING**: Handling empty responses
   * `:allow-empty-input-on-decode?` is now called `:allow-empty-input?`. It's a boolean:
     * `true` (default): empty input(stream) is decoded into `nil`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.3.0-SNAPSHOT
 
-* **BREAKING**: Drop default support for manual encoding of records.
-  * Guide how to enable it in the wiki: https://github.com/metosin/muuntaja/wiki/Configuration#manual-encoding
+* **BREAKING**: Drop default support for custom encoding of records.
+  * Guide how to enable it in the wiki: https://github.com/metosin/muuntaja/wiki/Configuration#custom-encoding
 
 * **BREAKING**: Handling empty responses
   * `:allow-empty-input-on-decode?` is now called `:allow-empty-input?`. It's a boolean:

--- a/README.md
+++ b/README.md
@@ -191,17 +191,13 @@ be used in the response pipeline.
 
  :default-format "application/json"
  :formats {"application/json" {:decoder [formats/make-json-decoder {:key-fn true}]
-                               :encoder [formats/make-json-encoder]
-                               :encode-protocol [formats/EncodeJson formats/encode-json]}
+                               :encoder [formats/make-json-encoder]}
            "application/edn" {:decoder [formats/make-edn-decoder]
-                              :encoder [formats/make-edn-encoder]
-                              :encode-protocol [formats/EncodeEdn formats/encode-edn]}
+                              :encoder [formats/make-edn-encoder]}
            "application/transit+json" {:decoder [(partial formats/make-transit-decoder :json)]
-                                       :encoder [(partial formats/make-transit-encoder :json)]
-                                       :encode-protocol [formats/EncodeTransitJson formats/encode-transit-json]}
+                                       :encoder [(partial formats/make-transit-encoder :json)]}
            "application/transit+msgpack" {:decoder [(partial formats/make-transit-decoder :msgpack)]
-                                          :encoder [(partial formats/make-transit-encoder :msgpack)]
-                                          :encode-protocol [formats/EncodeTransitMessagePack formats/encode-transit-msgpack]}}}
+                                          :encoder [(partial formats/make-transit-encoder :msgpack)]}}}
 
 ```
 

--- a/src/clj/muuntaja/core.clj
+++ b/src/clj/muuntaja/core.clj
@@ -222,9 +222,7 @@
    :formats {"application/json" json-format/json-format
              "application/edn" edn-format/edn-format
              "application/transit+json" transit-format/transit-json-format
-             "application/transit+msgpack" transit-format/transit-msgpack-format
-             #_#_"application/msgpack" msgpack-format/msgpack-format
-             #_#_"application/x-yaml" yaml-format/yaml-format}})
+             "application/transit+msgpack" transit-format/transit-msgpack-format}})
 
 ;;
 ;; HTTP stuff

--- a/src/clj/muuntaja/format/edn.clj
+++ b/src/clj/muuntaja/format/edn.clj
@@ -20,9 +20,6 @@
   (fn [data _]
     (pr-str data)))
 
-(defprotocol EncodeEdn
-  (encode-edn [this charset]))
-
 ;;
 ;; format
 ;;
@@ -31,8 +28,7 @@
 
 (def edn-format
   {:decoder [make-edn-decoder]
-   :encoder [make-edn-encoder]
-   :encode-protocol [EncodeEdn encode-edn]})
+   :encoder [make-edn-encoder]})
 
 (defn with-edn-format [options]
   (assoc-in options [:formats edn-type] edn-format))

--- a/src/clj/muuntaja/format/json.clj
+++ b/src/clj/muuntaja/format/json.clj
@@ -35,9 +35,6 @@
           options)
         (.flush output-stream)))))
 
-(defprotocol EncodeJson
-  (encode-json [this charset]))
-
 ;; muuntaja.json - experimental
 
 (defn ^:no-doc make-muuntaja-json-decoder [{:keys [keywords?]}]
@@ -71,16 +68,14 @@
 
 (def json-format
   {:decoder [make-json-decoder {:key-fn true}]
-   :encoder [make-json-encoder]
-   :encode-protocol [EncodeJson encode-json]})
+   :encoder [make-json-encoder]})
 
 (def streaming-json-format
   (assoc json-format :encoder [make-streaming-json-encoder]))
 
 (def muuntaja-json-format
   {:decoder [make-muuntaja-json-decoder {:keywords? true}]
-   :encoder [make-muuntaja-json-encoder]
-   :encode-protocol [EncodeJson encode-json]})
+   :encoder [make-muuntaja-json-encoder]})
 
 (def streaming-muuntaja-json-format
   (assoc muuntaja-json-format :encoder [make-streaming-muuntaja-json-encoder]))

--- a/src/clj/muuntaja/format/msgpack.clj
+++ b/src/clj/muuntaja/format/msgpack.clj
@@ -34,9 +34,6 @@
       (ByteArrayInputStream.
         (.toByteArray out-stream)))))
 
-(defprotocol EncodeMsgpack
-  (encode-msgpack [this charset]))
-
 ;;
 ;; format
 ;;
@@ -45,8 +42,7 @@
 
 (def msgpack-format
   {:decoder [make-msgpack-decoder {:keywords? true}]
-   :encoder [make-msgpack-encoder]
-   :encode-protocol [EncodeMsgpack encode-msgpack]})
+   :encoder [make-msgpack-encoder]})
 
 (defn with-msgpack-format [options]
   (assoc-in options [:formats msgpack-type] msgpack-format))

--- a/src/clj/muuntaja/format/transit.clj
+++ b/src/clj/muuntaja/format/transit.clj
@@ -29,12 +29,6 @@
             (transit/writer output-stream full-type options) data)
           (.flush output-stream))))))
 
-(defprotocol EncodeTransitJson
-  (encode-transit-json [this charset]))
-
-(defprotocol EncodeTransitMessagePack
-  (encode-transit-msgpack [this charset]))
-
 ;;
 ;; formats
 ;;
@@ -43,8 +37,7 @@
 
 (def transit-json-format
   {:decoder [(partial make-transit-decoder :json)]
-   :encoder [(partial make-transit-encoder :json)]
-   :encode-protocol [EncodeTransitJson encode-transit-json]})
+   :encoder [(partial make-transit-encoder :json)]})
 
 (defn with-transit-json-format [options]
   (assoc-in options [:formats transit-json-type] transit-json-format))
@@ -59,8 +52,7 @@
 
 (def transit-msgpack-format
   {:decoder [(partial make-transit-decoder :msgpack)]
-   :encoder [(partial make-transit-encoder :msgpack)]
-   :encode-protocol [EncodeTransitMessagePack encode-transit-msgpack]})
+   :encoder [(partial make-transit-encoder :msgpack)]})
 
 (defn with-transit-msgpack-format [options]
   (assoc-in options [:formats transit-msgpack-type] transit-msgpack-format))

--- a/src/clj/muuntaja/format/yaml.clj
+++ b/src/clj/muuntaja/format/yaml.clj
@@ -17,9 +17,6 @@
         (.getBytes
           ^String (apply yaml/generate-string data options-args))))))
 
-(defprotocol EncodeYaml
-  (encode-yaml [this charset]))
-
 ;;
 ;; format
 ;;
@@ -28,8 +25,7 @@
 
 (def yaml-format
   {:decoder [make-yaml-decoder {:keywords true}]
-   :encoder [make-yaml-encoder]
-   :encode-protocol [EncodeYaml encode-yaml]})
+   :encoder [make-yaml-encoder]})
 
 (defn with-yaml-format [options]
   (assoc-in options [:formats yaml-type] yaml-format))


### PR DESCRIPTION
Remove the manual enconding by default. It's mostly  not needed. Guide on wiki how to enable that back.