### PR TITLE
Better opts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
   * `:mapper` option can be used to set the preconfigured `ObjectMapper`.
 * move everyting from `muuntaja.records` into `muuntaja.core`
 * `m/slurp` to consume whatever Muuntaja can encode into a String. Not performance optimized, e.g. for testing.
-* Encoders can now return `muuntaja.protocols/ByteResponse`, a wrapper for `byte-array`. It can be streamed effectively with both Ring (via `ring.protocols/StreamableResponseBody`) and via NIO-enabled servers like [Aleph](https://github.com/ztellman/aleph) and [Immutant (perf fork)](https://github.com/ikitommi/immutant/pull/1)
-  * all defaults formats (json, edn & transit) returns these by default
+* **BREAKING**: for performance reasons, encoders must now return `byte[]` Instead of `ByteArrayInputStream`.
+  * It can be streamed effectively with both Ring (via `ring.protocols/StreamableResponseBody`) and via NIO-enabled servers like [Aleph](https://github.com/ztellman/aleph) and [Immutant (perf fork)](https://github.com/ikitommi/immutant/pull/1)
   * JSON is 30% snappier now with Ring Streaming.
 * formats can now also take `:opts` keys, which gets merged into encoder and decoder arguments and opts, so these decoders are effectively the same:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,46 @@
   * The `muuntaja.format.json` formatter takes now jsonista options directly, with an asertion to fail fast if old options are used:
      * `:key-fn` => `:encode-key-fn` and `:decode-key-fn`
      * `:bigdecimals?` => `:bigdecimals`
+  * `:mapper` option can be used to set the preconfigured `ObjectMapper`.
 * move everyting from `muuntaja.records` into `muuntaja.core`
 * Encoders can now return `muuntaja.protocols/ByteResponse`, a wrapper for `byte-array`. It can be streamed effectively with both Ring (via `ring.protocols/StreamableResponseBody`) and via NIO-enabled servers like [Aleph](https://github.com/ztellman/aleph) and [Immutant (perf fork)](https://github.com/ikitommi/immutant/pull/1)
   * all defaults formats (json, edn & transit) returns these by default
   * JSON is 30% snappier now with Ring Streaming.
+* formats can now also take `:opts` keys, which gets merged into encoder and decoder arguments and opts, so these decoders are effectively the same:
+
+```clj
+(require '[muuntaja.core :as m])
+
+(m/decoder
+  (m/create
+    (assoc-in
+      m/default-options
+      [:formats "application/json" :opts]
+      {:decode-key-fn false}))
+  "application/json")
+
+(m/decoder
+  (m/create
+    (assoc-in
+      m/default-options
+      [:formats "application/json" :decoder-opts]
+      {:decode-key-fn false}))
+  "application/json")
+```
+
+... and also this:
+
+```clj  
+(require '[jsonista.core :as j])
+
+(m/decoder
+  (m/create
+    (assoc-in
+      m/default-options
+      [:formats "application/json" :opts]
+      {:mapper (j/object-mapper {:decode-key-fn false})}))
+  "application/json")  
+```
 
 * dropped dependencies:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
      * `:bigdecimals?` => `:bigdecimals`
   * `:mapper` option can be used to set the preconfigured `ObjectMapper`.
 * move everyting from `muuntaja.records` into `muuntaja.core`
+* `m/slurp` to consume whatever Muuntaja can encode into a String. Not performance optimized, e.g. for testing.
 * Encoders can now return `muuntaja.protocols/ByteResponse`, a wrapper for `byte-array`. It can be streamed effectively with both Ring (via `ring.protocols/StreamableResponseBody`) and via NIO-enabled servers like [Aleph](https://github.com/ztellman/aleph) and [Immutant (perf fork)](https://github.com/ikitommi/immutant/pull/1)
   * all defaults formats (json, edn & transit) returns these by default
   * JSON is 30% snappier now with Ring Streaming.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Create a Muuntaja and use it to encode & decode JSON:
 (require '[muuntaja.core :as m])
 
 ;; with defaults
-(def m (muuntaja/create))
+(def m (m/create))
 
 (->> {:kikka 42}
      (m/encode m "application/json")

--- a/src/clj/muuntaja/core.clj
+++ b/src/clj/muuntaja/core.clj
@@ -304,11 +304,11 @@
           e)))))
 
 
-(defn- create-coder [format type spec spec-opts default-charset allow-empty-input? [p pf]]
+(defn- create-coder [format type spec opts spec-opts default-charset allow-empty-input? [p pf]]
   (let [decode? (= type :muuntaja/decode)
         g (if (vector? spec)
-            (let [[f opts] spec]
-              (f (merge opts spec-opts)))
+            (let [[f args] spec]
+              (f (merge args opts spec-opts)))
             spec)
         prepare (if decode? protocols/-input-stream identity)
         on-exception (partial on-exception allow-empty-input?)]
@@ -333,7 +333,7 @@
              (on-exception e format type))))))))
 
 (defn- create-adapters [formats default-charset allow-empty-input?]
-  (->> (for [[format {:keys [decoder decoder-opts encoder encoder-opts encode-protocol]}] formats]
+  (->> (for [[format {:keys [opts decoder decoder-opts encoder encoder-opts encode-protocol]}] formats]
          (if-not (or encoder decoder)
            (throw
              (ex-info
@@ -342,8 +342,8 @@
                 :formats (keys formats)}))
            [format (map->Adapter
                      (merge
-                       (if decoder {:decode (create-coder format :muuntaja/decode decoder decoder-opts default-charset allow-empty-input? nil)})
-                       (if encoder {:encode (create-coder format :muuntaja/encode encoder encoder-opts default-charset allow-empty-input? encode-protocol)})))]))
+                       (if decoder {:decode (create-coder format :muuntaja/decode decoder opts decoder-opts default-charset allow-empty-input? nil)})
+                       (if encoder {:encode (create-coder format :muuntaja/encode encoder opts encoder-opts default-charset allow-empty-input? encode-protocol)})))]))
        (into {})))
 
 (defn create

--- a/src/clj/muuntaja/core.clj
+++ b/src/clj/muuntaja/core.clj
@@ -1,4 +1,5 @@
 (ns muuntaja.core
+  (:refer-clojure :exclude [slurp])
   (:require [clojure.set :as set]
             [clojure.string :as str]
             [muuntaja.parse :as parse]
@@ -474,3 +475,10 @@
 (defmethod print-method ::muuntaja
   [_ ^Writer w]
   (.write w (str "<<Muuntaja>>")))
+
+;;
+;; Utilities
+;;
+
+(defn slurp [x]
+  (some-> x protocols/-input-stream clojure.core/slurp))

--- a/src/clj/muuntaja/core.clj
+++ b/src/clj/muuntaja/core.clj
@@ -154,6 +154,7 @@
           :encode-response-body? encode-collections-with-override}
 
    :allow-empty-input? true
+   :decode-into :input-stream ;; :byte-array :bytes
 
    :default-charset "utf-8"
    :charsets available-charsets
@@ -304,13 +305,18 @@
            :format format}
           e)))))
 
-
-(defn- create-coder [format type spec opts spec-opts default-charset allow-empty-input? [p pf]]
+(defn- create-coder [format type spec opts spec-opts default-charset allow-empty-input? decode-into [p pf]]
   (let [decode? (= type :muuntaja/decode)
-        g (if (vector? spec)
-            (let [[f args] spec]
-              (f (merge args opts spec-opts)))
-            spec)
+        g' (if (vector? spec)
+             (let [[f args] spec]
+               (f (merge args opts spec-opts)))
+             spec)
+        g (if decode?
+            g'
+            (case decode-into
+              :byte-array g'
+              :input-stream (comp util/byte-stream g')
+              :bytes (comp protocols/->ByteResponse g')))
         prepare (if decode? protocols/-input-stream identity)
         on-exception (partial on-exception allow-empty-input?)]
     (if (and p pf)
@@ -333,7 +339,7 @@
            (catch Exception e
              (on-exception e format type))))))))
 
-(defn- create-adapters [formats default-charset allow-empty-input?]
+(defn- create-adapters [formats default-charset allow-empty-input? decode-into]
   (->> (for [[format {:keys [opts decoder decoder-opts encoder encoder-opts encode-protocol]}] formats]
          (if-not (or encoder decoder)
            (throw
@@ -343,8 +349,8 @@
                 :formats (keys formats)}))
            [format (map->Adapter
                      (merge
-                       (if decoder {:decode (create-coder format :muuntaja/decode decoder opts decoder-opts default-charset allow-empty-input? nil)})
-                       (if encoder {:encode (create-coder format :muuntaja/encode encoder opts encoder-opts default-charset allow-empty-input? encode-protocol)})))]))
+                       (if decoder {:decode (create-coder format :muuntaja/decode decoder opts decoder-opts default-charset allow-empty-input? decode-into nil)})
+                       (if encoder {:encode (create-coder format :muuntaja/encode encoder opts encoder-opts default-charset allow-empty-input? decode-into encode-protocol)})))]))
        (into {})))
 
 (defn create
@@ -361,8 +367,9 @@
                    default-format
                    charsets
                    default-charset
-                   allow-empty-input?] :as options} muuntaja-or-options
-           adapters (create-adapters formats default-charset allow-empty-input?)
+                   allow-empty-input?
+                   decode-into] :as options} muuntaja-or-options
+           adapters (create-adapters formats default-charset allow-empty-input? decode-into)
            valid-format? (key-set formats identity)]
        (when-not (or (not default-format) (valid-format? default-format))
          (throw

--- a/src/clj/muuntaja/format/cheshire.clj
+++ b/src/clj/muuntaja/format/cheshire.clj
@@ -18,11 +18,7 @@
 
 (defn make-json-encoder [options]
   (fn [data ^String charset]
-    (ByteArrayInputStream. (.getBytes (cheshire/generate-string data options) charset))))
-
-(defn make-json-string-encoder [options]
-  (fn [data _]
-    (cheshire/generate-string data options)))
+    (.getBytes (cheshire/generate-string data options) charset)))
 
 (defn make-streaming-json-encoder [options]
   (fn [data ^String charset]

--- a/src/clj/muuntaja/format/edn.clj
+++ b/src/clj/muuntaja/format/edn.clj
@@ -12,14 +12,9 @@
 
 (defn make-edn-encoder [_]
   (fn [data ^String charset]
-    (protocols/->ByteResponse
-      (.getBytes
-        (pr-str data)
-        charset))))
-
-(defn make-edn-string-encoder [_]
-  (fn [data _]
-    (pr-str data)))
+    (.getBytes
+      (pr-str data)
+      charset)))
 
 ;;
 ;; format

--- a/src/clj/muuntaja/format/json.clj
+++ b/src/clj/muuntaja/format/json.clj
@@ -1,7 +1,6 @@
 (ns muuntaja.format.json
   (:require [jsonista.core :as j]
-            [muuntaja.protocols :as protocols]
-            [muuntaja.util :as util])
+            [muuntaja.protocols :as protocols])
   (:import (java.io InputStream
                     InputStreamReader
                     OutputStreamWriter

--- a/src/clj/muuntaja/format/json.clj
+++ b/src/clj/muuntaja/format/json.clj
@@ -1,6 +1,7 @@
 (ns muuntaja.format.json
   (:require [jsonista.core :as j]
-            [muuntaja.protocols :as protocols])
+            [muuntaja.protocols :as protocols]
+            [muuntaja.util :as util])
   (:import (java.io InputStream
                     InputStreamReader
                     OutputStreamWriter
@@ -36,10 +37,9 @@
 (defn make-json-encoder [options]
   (let [mapper (object-mapper! options)]
     (fn [data ^String charset]
-      (protocols/->ByteResponse
-        (if (.equals "utf-8" charset)
-          (j/write-value-as-bytes data mapper)
-          (.getBytes ^String (j/write-value-as-string data mapper) charset))))))
+      (if (.equals "utf-8" charset)
+        (j/write-value-as-bytes data mapper)
+        (.getBytes ^String (j/write-value-as-string data mapper) charset)))))
 
 (defn make-streaming-json-encoder [options]
   (let [mapper (object-mapper! options)]

--- a/src/clj/muuntaja/format/msgpack.clj
+++ b/src/clj/muuntaja/format/msgpack.clj
@@ -31,8 +31,7 @@
     (with-open [out-stream (ByteArrayOutputStream.)]
       (let [data-out (DataOutputStream. out-stream)]
         (msgpack/pack-stream (walk/stringify-keys data) data-out) options)
-      (ByteArrayInputStream.
-        (.toByteArray out-stream)))))
+      (.toByteArray out-stream))))
 
 ;;
 ;; format

--- a/src/clj/muuntaja/format/transit.clj
+++ b/src/clj/muuntaja/format/transit.clj
@@ -1,7 +1,7 @@
 (ns muuntaja.format.transit
   (:require [cognitect.transit :as transit]
             [muuntaja.protocols :as protocols])
-  (:import (java.io ByteArrayOutputStream ByteArrayInputStream OutputStream)))
+  (:import (java.io ByteArrayOutputStream OutputStream)))
 
 ;; uses default charset)
 
@@ -17,8 +17,7 @@
       (let [baos (ByteArrayOutputStream.)
             writer (transit/writer baos full-type options)]
         (transit/write writer data)
-        (protocols/->ByteResponse
-          (.toByteArray baos))))))
+        (.toByteArray baos)))))
 
 (defn make-streaming-transit-encoder [type {:keys [verbose] :as options}]
   (let [full-type (if (and (= type :json) verbose) :json-verbose type)]

--- a/src/clj/muuntaja/format/yaml.clj
+++ b/src/clj/muuntaja/format/yaml.clj
@@ -13,9 +13,8 @@
 (defn make-yaml-encoder [options]
   (let [options-args (mapcat identity options)]
     (fn [data ^String _]
-      (ByteArrayInputStream.
-        (.getBytes
-          ^String (apply yaml/generate-string data options-args))))))
+      (.getBytes
+        ^String (apply yaml/generate-string data options-args)))))
 
 ;;
 ;; format

--- a/src/clj/muuntaja/protocols.clj
+++ b/src/clj/muuntaja/protocols.clj
@@ -2,7 +2,8 @@
   (:require [clojure.java.io :as io]
             [muuntaja.util :as util])
   (:import (clojure.lang IFn AFn)
-           (java.io ByteArrayOutputStream ByteArrayInputStream InputStreamReader BufferedReader InputStream Writer OutputStream)))
+           (java.io ByteArrayOutputStream ByteArrayInputStream InputStreamReader BufferedReader InputStream Writer OutputStream FileInputStream File)
+           (java.nio ByteBuffer)))
 
 (deftype ByteResponse [bytes])
 
@@ -69,6 +70,12 @@
   (-input-stream ^java.io.InputStream [this]))
 
 (extend-protocol IntoInputStream
+  (Class/forName "[B")
+  (-input-stream [this] (ByteArrayInputStream. this))
+
+  File
+  (-input-stream [this] (FileInputStream. this))
+
   InputStream
   (-input-stream [this] this)
 

--- a/src/clj/muuntaja/protocols.clj
+++ b/src/clj/muuntaja/protocols.clj
@@ -18,6 +18,10 @@
 (util/when-ns
   'ring.core.protocols
   (extend-protocol ring.core.protocols/StreamableResponseBody
+    (Class/forName "[B")
+    (write-body-to-stream [this _ output-stream]
+      (.write ^OutputStream output-stream ^bytes this))
+
     ByteResponse
     (write-body-to-stream [this _ output-stream]
       (.write ^OutputStream output-stream ^bytes (.bytes this)))

--- a/src/clj/muuntaja/util.clj
+++ b/src/clj/muuntaja/util.clj
@@ -1,4 +1,8 @@
-(ns muuntaja.util)
+(ns muuntaja.util
+  (:import (java.io ByteArrayInputStream)))
+
+(defn byte-stream [^bytes bytes]
+  (ByteArrayInputStream. bytes))
 
 (defn throw! [formats format message]
   (throw

--- a/test/muuntaja/core_test.clj
+++ b/test/muuntaja/core_test.clj
@@ -196,7 +196,7 @@
   (testing "adding new format"
     (let [format "application/upper"
           upper-case-format {:decoder (fn [s _] (str/lower-case (slurp s)))
-                             :encoder (fn [s _] (protocols/-input-stream (str/upper-case s)))}
+                             :encoder (fn [s _] (.getBytes (str/upper-case s)))}
           m (m/create
               (-> m/default-options
                   (assoc-in [:formats format] upper-case-format)))

--- a/test/muuntaja/core_test.clj
+++ b/test/muuntaja/core_test.clj
@@ -7,12 +7,13 @@
             [muuntaja.format.yaml :as yaml-format]
             [jsonista.core :as j]
             [clojure.java.io :as io]
-            [muuntaja.protocols :as protocols])
+            [muuntaja.protocols :as protocols]
+            [muuntaja.util :as util])
   (:import (java.nio.charset Charset)
            (java.io FileInputStream)
            (java.nio.file Files)))
 
-(defn- to-byte-stream [x charset] (ByteArrayInputStream. (.getBytes x charset)))
+(defn- to-byte-stream [x charset] (util/byte-stream (.getBytes x charset)))
 
 (defn set-jvm-default-charset! [charset]
   (System/setProperty "file.encoding" charset)
@@ -79,7 +80,7 @@
         (is (= "UTF-16" (str (Charset/defaultCharset)))))))
 
   (testing "on empty input"
-    (let [empty (fn [] (ByteArrayInputStream. (byte-array 0)))
+    (let [empty (fn [] (util/byte-stream (byte-array 0)))
           m2 (m/create
                (-> m/default-options
                    (msgpack-format/with-msgpack-format)
@@ -291,9 +292,9 @@
         expected (slurp file)]
     (testing "bytes"
       (is (= expected (m/slurp (Files/readAllBytes (.toPath file))))))
-    (testing "file"
+    (testing "File"
       (is (= expected (m/slurp file))))
-    (testing "input-stream"
+    (testing "InputStream"
       (is (= expected (m/slurp (FileInputStream. file)))))
     (testing "StreamableResponse"
       (is (= expected (m/slurp (protocols/->StreamableResponse (partial io/copy file))))))

--- a/test/muuntaja/core_test.clj
+++ b/test/muuntaja/core_test.clj
@@ -227,9 +227,25 @@
                             m/default-options
                             [:formats "application/json" :decoder-opts]
                             {:decode-key-fn false}))
-                        "application/json")]
+                        "application/json")
+          decode-json2 (m/decoder
+                         (m/create
+                           (assoc-in
+                             m/default-options
+                             [:formats "application/json" :opts]
+                             {:decode-key-fn false}))
+                         "application/json")
+          decode-json3 (m/decoder
+                         (m/create
+                           (assoc-in
+                             m/default-options
+                             [:formats "application/json" :opts]
+                             {:mapper (j/object-mapper {:decode-key-fn false})}))
+                         "application/json")]
       (is (= {:kikka true} (decode-json-kw "{\"kikka\":true}")))
-      (is (= {"kikka" true} (decode-json "{\"kikka\":true}")))))
+      (is (= {"kikka" true} (decode-json "{\"kikka\":true}")))
+      (is (= {"kikka" true} (decode-json2 "{\"kikka\":true}")))
+      (is (= {"kikka" true} (decode-json3 "{\"kikka\":true}")))))
 
   (testing "overriding invalid adapter options fails"
     (is (thrown?

--- a/test/muuntaja/core_test.clj
+++ b/test/muuntaja/core_test.clj
@@ -2,13 +2,15 @@
   (:require [clojure.test :refer :all]
             [muuntaja.core :as m]
             [clojure.string :as str]
-            [muuntaja.protocols :as protocols]
             [muuntaja.format.cheshire :as cheshire-format]
             [muuntaja.format.msgpack :as msgpack-format]
             [muuntaja.format.yaml :as yaml-format]
-            [jsonista.core :as j])
+            [jsonista.core :as j]
+            [clojure.java.io :as io]
+            [muuntaja.protocols :as protocols])
   (:import (java.nio.charset Charset)
-           (java.io ByteArrayInputStream)))
+           (java.io FileInputStream)
+           (java.nio.file Files)))
 
 (defn- to-byte-stream [x charset] (ByteArrayInputStream. (.getBytes x charset)))
 
@@ -283,3 +285,21 @@
                   (assoc-in
                     [:formats "application/json" :decoder-opts]
                     {:key-fn false}))))))))
+
+(deftest slurp-test
+  (let [file (io/file "dev-resources/json10b.json")
+        expected (slurp file)]
+    (testing "bytes"
+      (is (= expected (m/slurp (Files/readAllBytes (.toPath file))))))
+    (testing "file"
+      (is (= expected (m/slurp file))))
+    (testing "input-stream"
+      (is (= expected (m/slurp (FileInputStream. file)))))
+    (testing "StreamableResponse"
+      (is (= expected (m/slurp (protocols/->StreamableResponse (partial io/copy file))))))
+    (testing "ByteReponse"
+      (is (= expected (m/slurp (protocols/->ByteResponse (Files/readAllBytes (.toPath file)))))))
+    (testing "String"
+      (is (= expected (m/slurp expected))))
+    (testing "nil"
+      (is (= nil (m/slurp nil))))))

--- a/test/muuntaja/formats_perf_test.clj
+++ b/test/muuntaja/formats_perf_test.clj
@@ -8,7 +8,8 @@
             [muuntaja.protocols :as mp]
             [jsonista.core :as j]
             [ring.core.protocols :as protocols]
-            [clojure.java.io :as io])
+            [clojure.java.io :as io]
+            [cheshire.core :as cheshire])
   (:import (java.io ByteArrayOutputStream ByteArrayInputStream)))
 
 (set! *warn-on-reflection* true)
@@ -46,8 +47,16 @@
 
 (def +charset+ "utf-8")
 
+(defn make-json-string-encoder [options]
+  (fn [data _]
+    (cheshire/generate-string data options)))
+
+(defn make-cheshire-string-encoder [options]
+  (fn [data _]
+    (cheshire/generate-string data options)))
+
 (defn encode-json []
-  (let [encode0 (cheshire-format/make-json-string-encoder {})
+  (let [encode0 (make-json-string-encoder {})
         encode1 (cheshire-format/make-streaming-json-encoder {})
         encode2 (cheshire-format/make-json-encoder {})
         encode3 (json-format/make-json-encoder {})]
@@ -85,7 +94,7 @@
         (call)))))
 
 (defn encode-json-ring []
-  (let [encode0 (cheshire-format/make-json-string-encoder {})
+  (let [encode0 (make-cheshire-string-encoder {})
         encode1 (cheshire-format/make-streaming-json-encoder {})
         encode2 (cheshire-format/make-json-encoder {})]
 
@@ -188,8 +197,12 @@
       (cc/quick-bench
         (call)))))
 
+(defn make-edn-string-encoder [_]
+  (fn [data _]
+    (pr-str data)))
+
 (defn encode-edn-ring []
-  (let [encode1 (edn-format/make-edn-string-encoder {})
+  (let [encode1 (make-edn-string-encoder {})
         encode2 (edn-format/make-edn-encoder {})]
 
     ;; 8.8µs

--- a/test/muuntaja/ring_middleware/format_response_test.clj
+++ b/test/muuntaja/ring_middleware/format_response_test.clj
@@ -291,7 +291,7 @@
   (wrap-api-response
     identity
     (-> m/default-options
-        (assoc-in [:formats "text/foo"] {:encoder (constantly "foobar")}))))
+        (assoc-in [:formats "text/foo"] {:encoder (constantly (.getBytes "foobar"))}))))
 
 (deftest format-custom-api-hashmap
   (let [req {:body {:foo "bar"} :headers {"accept" "text/foo"}}


### PR DESCRIPTION
# DONE

* encoder return `byte[]`
* via muuntaja opts one can configure encoding to return on of: `:input-stream` (default), `:byte-array` or `:bytes`
* `m/slurp` to slurp 'em all

# TODO

* streaming-encoders don't work now. and there are no tests for those
* should the encoder be responsible to return on of the types?

# new c-api with `:byte-array` responses:

<img width="614" alt="screen shot 2018-06-18 at 10 20 58" src="https://user-images.githubusercontent.com/567532/41523082-5840455c-72e1-11e8-93d9-27566b08c55a.png">

