### PR TITLE
Setup cljdoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,4 @@ pom.xml*
 .lein-deps-sum
 .lein-repl-history
 .nrepl-port
-/doc/
 \#*\#

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,14 @@ Please file bug reports and feature requests to https://github.com/metosin/muunt
 * Push your code to your fork of the repository
 * Make a Pull Request
 
+Installing jars and changing of version numbers can be done with the following scripts:
+
+```sh
+./script/set-version 1.0.0
+./script/lein-modules install
+```
+
+
 ## Commit messages
 
 1. Separate subject from body with a blank line

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Muuntaja [![Continuous Integration status](https://secure.travis-ci.org/metosin/muuntaja.png)](http://travis-ci.org/metosin/muuntaja)
+# Muuntaja [![Continuous Integration status](https://secure.travis-ci.org/metosin/muuntaja.png)](http://travis-ci.org/metosin/muuntaja) [![cljdoc badge](https://cljdoc.xyz/badge/metosin/muuntaja)](https://cljdoc.xyz/jump/release/metosin/muuntaja)
 
 <img src="https://raw.githubusercontent.com/wiki/metosin/muuntaja/muuntaja-small.png" align="right"/>
 
@@ -8,7 +8,7 @@ out-of-the-box [JSON](http://www.json.org/), [EDN](https://github.com/edn-format
 Ships with optional adapters for [MessagePack](http://msgpack.org/) and [YAML](http://yaml.org/).
 
 Based on [ring-middleware-format](https://github.com/ngrunwald/ring-middleware-format),
-but a complete rewrite ([and up to 30x faster](https://github.com/metosin/muuntaja/wiki/Performance)).
+but a complete rewrite ([and up to 30x faster](doc/Performance.md)).
 
 ## Rationale
 
@@ -31,7 +31,8 @@ but a complete rewrite ([and up to 30x faster](https://github.com/metosin/muunta
 
 * [Muuntaja, a boring library everyone should use](https://www.metosin.fi/blog/muuntaja/)
 
-Check the [Wiki](https://github.com/metosin/muuntaja/wiki) & [api-docs](http://metosin.github.com/muuntaja) for more details.
+Check [the docs on cljdoc.xyz](https://cljdoc.xyz/jump/release/metosin/muutaja)
+for detailed API documentation as well as more guides on how to use Muuntaja.
 
 ## Latest version
 
@@ -73,7 +74,7 @@ Muuntaja requires Java 1.8+
 ;  :headers {"Content-Type" "application/json; charset=utf-8"}}
 ```
 
-There is a [Ring guide](https://github.com/metosin/muuntaja/wiki/With-Ring) in a wiki. See also [differences](https://github.com/metosin/muuntaja/wiki/Differences-to-existing-formatters) to ring-middleware-format & ring-json if you are migrating from those.
+There is a more detailed [Ring guide](doc/With-Ring.md) too. See also [differences](doc/Differences-to-existing-formatters.md) to ring-middleware-format & ring-json if you are migrating from those.
 
 ## Interceptors
 
@@ -188,7 +189,8 @@ All return types satisfy the following Protocols & Interfaces:
 
 HTTP format negotiation is done via request headers for both request (`content-type`, including the charset)
 and response (`accept` and `accept-charset`). With the default options, a full match on the content-type is
-required, e.g. `application/json`. Adding a `:matches` regexp for formats enables more loose matching. See [Configuration wiki-page](https://github.com/metosin/muuntaja/wiki/Configuration#loose-matching-on-content-type) for more info.
+required, e.g. `application/json`. Adding a `:matches` regexp for formats enables more loose matching.
+See [Configuration docs](doc/Configuration.md#loose-matching-on-content-type) for more info.
 
 Results of the negotiation are published into request & response under namespaced keys for introspection.
 These keys can also be set manually, overriding the content negotiation process.

--- a/doc/Configuration.md
+++ b/doc/Configuration.md
@@ -1,0 +1,249 @@
+# Configuration
+
+Muuntaja is data-driven, allowing [mostly](#evil-global-state) everything to be defined via options. Muuntaja is created with `muuntaja.core/create` function. It takes either an existing Muuntaja instance, options-map or nothing as a parameter.
+
+## Examples
+
+```clj
+(require '[muuntaja.core :as muuntaja])
+
+;; with defaults
+(def m (muuntaja/create))
+
+;; with a muuntaja as prototype (no-op)
+(muuntaja/create m)
+
+;; with default options (same features, different instance)
+(muuntaja/create muuntaja/default-options)
+```
+
+## Default options
+
+```clj
+{:http {:extract-content-type extract-content-type-ring
+        :extract-accept-charset extract-accept-charset-ring
+        :extract-accept extract-accept-ring
+        :decode-request-body? (constantly true)
+        :encode-reseponse-body? encode-collections-with-override}
+
+ :default-charset "utf-8"
+ :charsets muuntaja/available-charsets
+
+ :default-format "application/json"
+ :formats {"application/json" {:decoder [formats/make-json-decoder {:key-fn true}]
+                               :encoder [formats/make-json-encoder]}
+           "application/edn" {:decoder [formats/make-edn-decoder]
+                              :encoder [formats/make-edn-encoder]}
+           "application/transit+json" {:decoder [(partial formats/make-transit-decoder :json)]
+                                       :encoder [(partial formats/make-transit-encoder :json)]}
+           "application/transit+msgpack" {:decoder [(partial formats/make-transit-decoder :msgpack)]
+                                          :encoder [(partial formats/make-transit-encoder :msgpack)]}}}
+```
+
+## Custom options
+
+As options are just data, normal Clojure functions can be used to modify them. Options are sanity checked at creation time. There are also the following helpers in the `muuntaja.core`:
+
+* `select-formats`: takes a sequence of formats selecting them and setting the first one as default format.
+* `transform-formats` takes an 2-arity function [format, format-options], which returns new format-options for that format. Returning `nil` removes that format. Called for all registered formats.
+
+## Examples
+
+### Modifying JSON encoding opts
+
+Easiest way is to add a `:encoder-opts` key to the format with the options map as the value.
+
+```clj
+(def m
+  (muuntaja/create
+    (assoc-in
+      muuntaja/default-options
+      [:formats "application/json" :encoder-opts]
+      {:key-fn #(.toUpperCase (name %))})))
+
+(slurp (muuntaja/encode m "application/json" {:kikka 42}))
+;; "{\"KIKKA\":42}"
+```
+
+### Setting Transit writers and readers
+
+```clj
+(def m
+  (muuntaja/create
+    (update-in
+      muuntaja/default-options
+      [:formats "application/transit+json"]
+      merge {:decoder-opts {:handlers transit-dates/readers}
+             :encoder-opts {:handlers transit-dates/writers}})))
+```
+
+### Using only selected formats
+
+Supporting only `application/edn` and `application/transit+json` formats.
+
+```clj
+(def m
+  (muuntaja/create
+    (-> muuntaja/default-options
+        (update
+          :formats
+          select-keys
+          ["application/edn"
+           "application/transit+json"]))))
+;; clojure.lang.ExceptionInfo Invalid default format application/json
+```
+
+Ups. That didn't work. The `:default-format` is now illegal. This works:
+
+```clj
+(def m
+  (muuntaja/create
+    (-> muuntaja/default-options
+        (update
+          :formats
+          select-keys
+          ["application/edn"
+           "application/transit+json"])
+        (assoc :default-format "application/edn"))))
+```
+
+Same with `select-formats`:
+
+```clj
+(def m
+  (muuntaja/create
+    (muuntaja/select-formats
+      muuntaja/default-options
+      ["application/json"
+       "application/edn"])))
+
+(:default-format m)
+; "application/edn"
+```
+
+### Disabling decoding
+
+We have to remove `:decoder` key from all formats.
+
+```clj
+(def m
+  (muuntaja/create
+    (update
+      muuntaja/default-options
+      :formats
+      #(into
+        (empty %)
+        (map (fn [[k v]]
+               [k (dissoc v :decoder)]) %)))))
+
+(muuntaja/encoder m "application/json")
+;; #object[...]
+
+(muuntaja/decoder m "application/json")
+;; nil
+```
+
+Same with `transform-formats`:
+
+```clj
+(def m
+  (muuntaja/create
+    (muuntaja/transform-formats
+      muuntaja/default-options
+      #(dissoc %2 :encoder))))
+```
+
+### Using Streaming JSON and Transit encoders
+
+To be used with Ring 1.6.0+, with Pedestal & other streaming libs. We have
+to change the `:encoder` of the given formats:
+
+```clj
+(require '[muuntaja.format.json :as json-format])
+(require '[muuntaja.format.transit :as transit-format])
+
+(def m
+  (muuntaja/create
+    (-> muuntaja/default-options
+        (assoc-in
+          [:formats "application/json" :encoder 0]
+          json-format/make-streaming-json-encoder)
+        (assoc-in
+          [:formats "application/transit+json" :encoder 0]
+          (partial transit-format/make-streaming-transit-encoder :json))
+        (assoc-in
+          [:formats "application/transit+msgpack" :encoder 0]
+          (partial transit-format/make-streaming-transit-encoder :msgpack)))))
+
+(muuntaja/encode m "application/json" {:kikka 2})
+;; <<StreamableResponse>>
+
+(slurp (muuntaja/encode m "application/json" {:kikka 2}))
+; "{\"kikka\":2}"
+```
+
+### Loose matching on content-type
+
+If, for some reason, you want use the RegExps to match the content-type (like
+`ring-json`, `ring-transit` & `ring-middleware-format` do. We need just to add
+a `:matches` key to format with a regexp as a value. The following procudes loose
+matching like in `ring-middleware-format`:
+
+```clj
+(def m
+  (muuntaja/create
+    (-> muuntaja/default-options
+        (assoc-in [:formats "application/json" :matches] #"^application/(.+\+)?json$")
+        (assoc-in [:formats "application/edn" :matches] #"^application/(vnd.+)?(x-)?(clojure|edn)$")
+        ;(assoc-in [:formats "application/msgpack" :matches] #"^application/(vnd.+)?(x-)?msgpack$")
+        ;(assoc-in [:formats "application/x-yaml" :matches] #"^(application|text)/(vnd.+)?(x-)?yaml$")
+        (assoc-in [:formats "application/transit+json" :matches] #"^application/(vnd.+)?(x-)?transit\+json$")
+        (assoc-in [:formats "application/transit+msgpack" :matches] #"^application/(vnd.+)?(x-)?transit\+msgpack$"))))
+
+((:negotiate-content-type m) "application/vnd.foobar+json; charset=utf-8")
+;; #muuntaja.core.FormatAndCharset{:format "application/json", :charset "utf-8"}
+```
+
+### Custom encoding
+
+Muuntaja supports custom encoding for Records. To enable this, one has to create a custom Protocol with a 2-arity function of `data charset => byte-stream` and mount it to formatter under `:encode-protocol` with a vector containing the protocol and it's function:
+
+```clj
+;; custom protocol to encode JSON
+(defprotocol EncodeJson
+  ;; the 2-arity callback
+  (encode-json [this charset]))
+
+;; mount it to a formatter
+(def m
+  (muuntaja/create
+    (-> muuntaja/default-options
+        (assoc-in
+          [:formats "application/json" :encode-protocol]
+          [EncodeJson encode-json]))))
+
+;; custom record with hand-crafted JSON:
+(defrecord Hello []
+  EncodeJson
+  (encode-json [_ _]
+    (ByteArrayInputStream.
+      (.getBytes "{\"hello\":\"world\"}"))))
+
+
+(->> (->Hello)
+     (muuntaja/encode m "application/json")
+     (muuntaja/decode m "application/json"))
+; {:hello "world"}
+```
+
+### Creating a new format
+
+See [[Creating new formats]].
+
+### Implicit configuration
+
+Currently, both `cheshire` & `clojure-msgpack` allow new type encoders to be defined via Clojure protocol extensions. Importing a namespace could bring new type mappings or override existings without a warning, potentially breaking things. Ordering of the imports should not matter!
+
+TODO: Make all options explicit.
+
+* See: https://github.com/dakrone/cheshire/issues/7

--- a/doc/Creating-new-formats.md
+++ b/doc/Creating-new-formats.md
@@ -1,0 +1,55 @@
+# Creating new formats
+
+Formats are presented as Clojure maps, registered into options under `:formats` with format name as a key.
+Format maps can the following optional keys:
+
+* `:decoder` a function (or a function generator) to parse an InputStreams into Clojure data structure. If the key is missing or value is `nil`, no decoding will be done.
+* `:encoder` a function (or a function generator) to encode Clojure data structures into an `InputStream` or to `muuntaja.protocols/Stremable`. If the key is missing or value is `nil`, no encoding will be done.
+* `:decoder-opts` extra options maps for the decoder function generator.
+* `:encoder-opts` extra options maps for the encoder function generator.
+* `:matches` a regexp for additional matching of the content-type in request negotiation. Added for legacy support, e.g. `#"^application/(.+\+)?json$"`. Results of the regexp are memoized against the given content-type for near constant-time performance.
+* `:encode-protocol` vector tuple of protocol name and function that can be used to encode a data.
+
+## Function generators
+
+To allow easier customization of the formats on the client side, function generators can be used instead of plain functions. Function generators have a [Duct](https://github.com/duct-framework/duct)/[Reagent](https://github.com/reagent-project/reagent)-style vector presentations with the generator function & optionally the default opts for it.
+
+```clj
+{:decoder [json-format/make-json-decoder]}
+;; => (json-format/make-json-decoder {})
+
+{:decoder [formats/make-json-decoder {:key-fn true}]}
+;; => (json-format/make-json-decoder {:key-fn true})
+```
+
+Clients can override format options with providing `:decoder-opts` or `:encoder-opts`. These get merged over the default opts.
+
+```clj
+{:decoder [formats/make-json-decoder {:key-fn true}]
+ :decoder-opts {:bigdecimals? true}
+;; => (json-format/make-json-decoder {:key-fn true, :bigdecimals? true})
+```
+
+## Example of a new format
+
+```clj
+(require '[muuntaja.format.json :as json-format])
+(require '[clojure.string :as str])
+(require '[muuntaja.core :as muuntaja])
+
+(def streaming-upper-case-json-format
+ {:decoder [json-format/make-json-decoder {:keywords? false, :key-fn str/upper-case}]
+  :encoder [json-format/make-streaming-json-encoder]})
+
+(def m
+  (muuntaja/create
+    (assoc-in
+      muuntaja/default-options
+      [:formats "application/upper-json"]
+      streaming-upper-case-json-format)))
+
+(->> {:kikka 42}
+     (muuntaja/encode m "application/json")
+     (muuntaja/decode m "application/upper-json"))
+; {"KIKKA" 42}
+```

--- a/doc/Differences-to-existing-formatters.md
+++ b/doc/Differences-to-existing-formatters.md
@@ -1,0 +1,42 @@
+# Differences to existing formatters
+
+Both `ring-json` and `ring-middleware-format` tests have been ported to muuntaja to
+verify behavior and demonstrate differences.
+
+## Middleware
+
+### Common
+
+* By default, Keywords are used in map keys (good for `clojure.spec` & `Schema`)
+* By default, requires exact string match on content-type
+  * regex-matches can be enabled manually via options
+* No in-built exception handling
+  * Exceptions have `:type` of `:muuntaja/***`, catch them elsewhere
+  * Optionally use `muuntaja.middleware/wrap-exception` to catch 'em
+* Does not merge `:body-params` into `:params`
+  * Because merging persistent HashMaps is slow.
+  * Optionally add `muuntaja.middleware/wrap-params` to your mw-stack before `muuntaja.middleware/wrap-format`
+
+### Ring-json & ring-transit
+
+* Supports multiple formats in a single middleware
+* Returns Stream responses instead of Strings
+* Does not populate the `:json-params`/`:transit-params`
+  * If you need these, write your own middleware for this.
+
+### Ring-middleware-format
+
+* Does not recreate a `:body` stream after consuming the body
+* Multiple `wrap-format` (or `wrap-request`) middleware can be used in the same mw stack, first one acts, rest are no-op
+* By default, encodes only collections (or responses with `:muuntaja/encode?` set)
+* By default, reads the `content-type` from request headers (as defined in the RING Spec), not `:content-type` request key
+* Does not set the `Content-Length` header (which is done by the ring-adapters)
+* `:yaml-in-html` / `text/html` is not supported, roll you own formats if you need these
+* `:yaml` and `:msgpack` are not set on by default
+
+## Pedestal Interceptors
+
+**TODO**
+
+* Decoded body is set always to `:body-params`
+  * Does not populate the `:json-params`/`:transit-params`, if you need these, write an extra interceptor for this.

--- a/doc/Performance.md
+++ b/doc/Performance.md
@@ -1,0 +1,69 @@
+# Performance
+
+## Background
+
+Muuntaja has been built with performance in mind, while still doing mostly everything in Clojure:
+
+* single middleware/interceptor for all formats (instead of stacked middleware)
+* avoid run-time regexps
+* avoid dynamic bindings
+* avoid Clojure (map) destructuring
+* (Java-backed) memoized content negotiation
+* Protocols over Multimethods
+* Records over Maps
+* use field access instead of lookups
+* keep all core functions small enough to enable JVM Inlining
+* unroll generic functions (like `get-in`)
+* use streaming when possible
+
+The codebase contains the performance test, done using [Criterium](https://github.com/hugoduncan/criterium) under the `perf` Leiningen profile with a 2013 Mackbook pro.
+
+**NOTE:** Tests are not scientific proof and may contain errors. If you have idea how to test things better, please poke us.
+
+## Middleware
+
+Muuntaja is tested against the current common ring-based formatters. It's fastest in [all tests](https://github.com/metosin/muuntaja/blob/master/test/muuntaja/core_perf_test.clj).
+
+### `[ring/ring-json "0.4.0"]` & `[ring-transit "0.1.6"]`
+
+* ok performance by default, but only provide a single format - Stacking these separate middleware makes the pipeline slower.
+
+### `[ring-middleware-format "0.7.0"]`
+
+* has really bad defaults:
+   * with 1K JSON, Muuntaja is 10-30x faster (depending on the JSON encoder used)
+   * with 100k JSON, Muuntaja is still 2-4x faster
+* with tuned r-m-f options
+   * with <1K messages, Muuntaja is still much faster
+   * similar perf on large messages
+
+### JSON
+![perf-json-relative](https://raw.githubusercontent.com/wiki/metosin/muuntaja/perf/perf-json-relative.png)
+![perf-json-relative2](https://raw.githubusercontent.com/wiki/metosin/muuntaja/perf/perf-json-relative2.png)
+![perf-json](https://raw.githubusercontent.com/wiki/metosin/muuntaja/perf/perf-json.png)
+
+## Transit
+![perf-transit](https://raw.githubusercontent.com/wiki/metosin/muuntaja/perf/perf-transit.png)
+![perf-transit-relative](https://raw.githubusercontent.com/wiki/metosin/muuntaja/perf/perf-transit-relative.png)
+
+## Interceptors
+
+Pedestal:
+ * `io.pedestal.http.content-negotiation/negotiate-content` for content negotiation
+ * `io.pedestal.http.body-params/body-params` for decoding the request body
+ * `io.pedestal.http/json-body`, `io.pedestal.http/transit-json-body` etc. to encode responses
+
+Muuntaja:
+ * `muuntaja.interceptor/format-negotiate` for content negotiation
+ * `muuntaja.interceptor/format-request` for decoding request body
+ * `muuntaja.interceptor/format-response` to encode responses
+ * `muuntaja.interceptor/format` all on one step
+
+![interceptor-perf-json-relative2](https://raw.githubusercontent.com/wiki/metosin/muuntaja/perf/interceptors-perf-json-relative.png)
+![interceptor-perf-json-relative](https://raw.githubusercontent.com/wiki/metosin/muuntaja/perf/interceptors-perf-json.png)
+
+## Custom encoding
+
+Instead of using generic encoders, one can also do custom endocing for Records. This can yield better performance.
+
+See https://github.com/metosin/muuntaja/wiki/Configuration#custom-encoding for details.

--- a/doc/With-Ring.md
+++ b/doc/With-Ring.md
@@ -1,0 +1,118 @@
+# Usage with Ring
+
+## Simplest thing that works
+
+Let's create a Ring application that can read and write JSON, EDN and Transit.
+
+```clj
+(require '[muuntaja.middleware :as mw])
+
+(defn handler [_]
+  {:status 200
+   :body {:ping "pong"}})
+
+;; with defaults
+(def app (mw/wrap-format handler))
+
+(def request {:headers {"accept" "application/json"}})
+
+(->> request app)
+; {:status 200,
+;  :body #object[java.io.ByteArrayInputStream 0x1d07d794 "java.io.ByteArrayInputStream@1d07d794"],
+;  :muuntaja/format "application/transit+json",
+;  :headers {"Content-Type" "application/json; charset=utf-8"}}
+
+(->> request app :body slurp)
+; "{\"ping\":\"pong\"}"
+```
+
+## With Muuntaja instance
+
+As previous, but with custom Transit options and a standalone Muuntaja.
+
+```clj
+(require '[cognitect.transit :as transit])
+(require '[muuntaja.middleware :as mw])
+(require '[muuntaja.core :as m])
+
+;; custom Record
+(defrecord Ping [])
+
+;; custom transit handlers
+(def write-handlers
+  {Ping (transit/write-handler (constantly "Ping") (constantly {}))})
+
+(def read-handlers
+  {"Ping" (transit/read-handler map->Ping)})
+
+;; a configured Muuntaja
+(def muuntaja
+  (m/create
+    (update-in
+      m/default-options
+      [:formats "application/transit+json"]
+      merge
+      {:encoder-opts {:handlers write-handlers}
+       :decoder-opts {:handlers read-handlers}})))
+
+(defn endpoint [_]
+  {:status 200
+   :body {:ping (->Ping)}})
+
+(def app (-> endpoint (mw/wrap-format muuntaja)))
+
+(def request {:headers {"accept" "application/transit+json"}})
+
+(->> request app)
+; {:status 200,
+;  :body #object[java.io.ByteArrayInputStream 0x3478e74b "java.io.ByteArrayInputStream@3478e74b"],
+;  :muuntaja/format "application/transit+json",
+;  :headers {"Content-Type" "application/transit+json; charset=utf-8"}}
+
+(->> request app :body slurp)
+; "[\"^ \",\"~:ping\",[\"~#Ping\",[\"^ \"]]]"
+
+(->> request app :body (m/decode muuntaja "application/transit+json"))
+; {:ping #user.Ping{}}
+```
+
+## Middleware pipeline
+
+Muuntaja doesn't catch formatting exceptions itself, but throws them instead. If you want to format those also, you need to split the `wrap-format` into parts.
+
+so this:
+
+```clj
+(-> app (mw/wrap-format muuntaja))
+```
+
+can be written as:
+
+```clj
+(-> app
+    ;; format the request
+    (mw/wrap-format-request muuntaja)
+    ;; format the response
+    (mw/wrap-format-response muuntaja)
+    ;; negotiate the request & response formats
+    (mw/wrap-format-negotiate muuntaja))
+```
+Now you can add your own exception-handling mw between the `wrap-format-request` and `wrap-format-response`. It sees the formatting exceptions and it's results are written with the response formatter.
+
+Here's a "complete" stack:
+
+```clj
+(-> app
+    ;; support for `:params`
+    (mw/wrap-params)
+    ;; format the request
+    (mw/wrap-format-request muuntaja)
+    ;; catch exceptions
+    (mw/wrap-exceptions my-exception-handler)
+    ;; format the response
+    (mw/wrap-format-response muuntaja)
+    ;; negotiate the request & response formats
+    (mw/wrap-format-negotiate muuntaja))
+```
+
+See example of real-life use from [compojure-api](https://github.com/metosin/compojure-api/blob/master/src/compojure/api/middleware.clj). It also reads the `:produces` and `:consumes` from Muuntaja instance and passed them to [Swagger](swagger.io) docs. `:params`-support is needed to allow compojure destucturing syntax.

--- a/doc/cljdoc.edn
+++ b/doc/cljdoc.edn
@@ -1,0 +1,6 @@
+{:cljdoc.doc/tree [["Readme" {:file "README.md"}]
+                   ["Configuration" {:file "doc/Configuration.md"}]
+                   ["Creating new formats" {:file "doc/Creating-new-formats.md"}]
+                   ["Differences to existing formatters" {:file "doc/Differences-to-existing-formatters.md"}]
+                   ["Performance" {:file "doc/Performance.md"}]
+                   ["With Ring" {:file "doc/With-Ring.md"}]]}


### PR DESCRIPTION
This PR sets up muuntaja for [cljdoc](https://cljdoc.xyz). In summary this means moving the wiki into the repo and adding `doc/cljdoc.edn`. 

I fixed all links and added titles to all files and added a cljdoc badge to the Readme that points users to the most recent release on cljdoc.

Updating [existing docs](https://cljdoc.xyz/d/metosin/muuntaja/0.6.0-alpha1/doc/readme) isn't possible at this point so if this gets merged there will need to be a new release. (SNAPSHOT builds always use `master` as git revision.)

I hope this is useful 🙂 