### PR TITLE
Fixes #76

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 * move everyting from `muuntaja.records` into `muuntaja.core`
 * helpers `m/get-negotiated-request-content-type` & `m/get-negotiated-response-content-type`
 * `m/slurp` to consume whatever Muuntaja can encode into a String. Not performance optimized, e.g. for testing.
+* **BREAKING**: Changes in special Muuntaja keys in request & response
+  * `:muuntaja/format` is not published into request or response
+  * `muuntaja.core/disable-request-encoding` helper is removed
+  * `muuntaja.core/disable-response-encoding` helper is removed
+  * `:muuntaja/encode?` response key (to force encoding) is renamed to `:muuntaja/encode`
+* **BREAKING**: if a "Content-Type" header is set in a response, the body will not be encoded, unless `:muuntaja/encode` is set
 * **BREAKING**: formats are written as Protocols instead of just functions.
   * encoders should satisfy `muuntaja.format.core/EncodeToBytes` or `muuntaja.format.core/EncodeToOutputStream`
   * decoders should satisfy `muuntaja.format.core/Decode`

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ be used in the response pipeline.
         :extract-accept-charset extract-accept-charset-ring
         :extract-accept extract-accept-ring
         :decode-request-body? (constantly true)
-        :encode-response-body? encode-collections-with-override}
+        :encode-response-body? encode-collections}
 
  :allow-empty-input? true
  :return :input-stream

--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ Muuntaja requires Java 1.8+
       :body "{:kikka 42}"})
 ; {:status 200,
 ;  :body #object[java.io.ByteArrayInputStream]
-;  :muuntaja/format "application/json",
 ;  :headers {"Content-Type" "application/json; charset=utf-8"}}
 ```
 
@@ -209,8 +208,6 @@ have an `ex-data` with the following `:type` value (plus extra info to generate 
 
 ### Request
 
-* `:muuntaja/format`, format name that was used to decode the request body, e.g. `application/json`. If
-   the key is already present in the request map, muuntaja middleware/interceptor will skip the decoding process.
 * `:muuntaja/request`, client-negotiated request format and charset as `FormatAndCharset` record. Will
 be used in the response pipeline.
 * `:muuntaja/response`, client-negotiated response format and charset as `FormatAndCharset` record. Will
@@ -219,9 +216,7 @@ be used in the response pipeline.
 
 ### Response
 
-* `:muuntaja/encode?`, if set to true, the response body will be encoded regardles of the type (primitives!)
-* `:muuntaja/format`, format name that was used to encode the response body, e.g. `application/json`. If
-   the key is already present in the response map, muuntaja middleware/interceptor will skip the encoding process.
+* `:muuntaja/encode`, if set to truthy value, the response body will be encoded regardles of the type (primitives!)
 * `:muuntaja/content-type`, handlers can use this to override the negotiated content-type for response encoding,
    e.g. setting it to `application/edn` will cause the response to be formatted in JSON.
 

--- a/doc/Configuration.md
+++ b/doc/Configuration.md
@@ -24,20 +24,19 @@ Muuntaja is data-driven, allowing [mostly](#evil-global-state) everything to be 
         :extract-accept-charset extract-accept-charset-ring
         :extract-accept extract-accept-ring
         :decode-request-body? (constantly true)
-        :encode-reseponse-body? encode-collections-with-override}
+        :encode-response-body? encode-collections}
+
+ :allow-empty-input? true
+ :return :input-stream
 
  :default-charset "utf-8"
- :charsets muuntaja/available-charsets
+ :charsets available-charsets
 
  :default-format "application/json"
- :formats {"application/json" {:decoder [formats/make-json-decoder {:key-fn true}]
-                               :encoder [formats/make-json-encoder]}
-           "application/edn" {:decoder [formats/make-edn-decoder]
-                              :encoder [formats/make-edn-encoder]}
-           "application/transit+json" {:decoder [(partial formats/make-transit-decoder :json)]
-                                       :encoder [(partial formats/make-transit-encoder :json)]}
-           "application/transit+msgpack" {:decoder [(partial formats/make-transit-decoder :msgpack)]
-                                          :encoder [(partial formats/make-transit-encoder :msgpack)]}}}
+ :formats {"application/json" json-format/json-format
+           "application/edn" edn-format/edn-format
+           "application/transit+json" transit-format/transit-json-format
+           "application/transit+msgpack" transit-format/transit-msgpack-format}}
 ```
 
 ## Custom options

--- a/doc/Differences-to-existing-formatters.md
+++ b/doc/Differences-to-existing-formatters.md
@@ -28,7 +28,7 @@ verify behavior and demonstrate differences.
 
 * Does not recreate a `:body` stream after consuming the body
 * Multiple `wrap-format` (or `wrap-request`) middleware can be used in the same mw stack, first one acts, rest are no-op
-* By default, encodes only collections (or responses with `:muuntaja/encode?` set)
+* By default, encodes only collections (or responses with `:muuntaja/encode` set)
 * By default, reads the `content-type` from request headers (as defined in the RING Spec), not `:content-type` request key
 * Does not set the `Content-Length` header (which is done by the ring-adapters)
 * `:yaml-in-html` / `text/html` is not supported, roll you own formats if you need these

--- a/doc/With-Ring.md
+++ b/doc/With-Ring.md
@@ -19,7 +19,6 @@ Let's create a Ring application that can read and write JSON, EDN and Transit.
 (->> request app)
 ; {:status 200,
 ;  :body #object[java.io.ByteArrayInputStream 0x1d07d794 "java.io.ByteArrayInputStream@1d07d794"],
-;  :muuntaja/format "application/json",
 ;  :headers {"Content-Type" "application/json; charset=utf-8"}}
 
 (->> request app :body slurp)
@@ -66,7 +65,6 @@ As previous, but with custom Transit options and a standalone Muuntaja.
 (->> request app)
 ; {:status 200,
 ;  :body #object[java.io.ByteArrayInputStream 0x3478e74b "java.io.ByteArrayInputStream@3478e74b"],
-;  :muuntaja/format "application/transit+json",
 ;  :headers {"Content-Type" "application/transit+json; charset=utf-8"}}
 
 (->> request app :body slurp)

--- a/test/muuntaja/ring_json/json_test.clj
+++ b/test/muuntaja/ring_json/json_test.clj
@@ -253,7 +253,7 @@
               (= body "{\n  \"baz\" : \"quz\",\n  \"foo\" : \"bar\"\n}")))))
 
   (testing "don’t overwrite Content-Type if already set"
-    (let [handler (constantly {:status 200 :headers {"Content-Type" "application/json; some-param=some-value"} :body {:foo "bar"}})
+    (let [handler (constantly {:status 200 :headers {"Content-Type" "application/json; some-param=some-value"} :body {:foo "bar"}, :muuntaja/encode true})
           response ((wrap-json-response handler) {})
           body (-> response :body slurp)]
       (is (= (get-in response [:headers "Content-Type"]) "application/json; some-param=some-value"))

--- a/test/muuntaja/ring_json/json_test.clj
+++ b/test/muuntaja/ring_json/json_test.clj
@@ -252,9 +252,16 @@
       (is (or (= body "{\n  \"foo\" : \"bar\",\n  \"baz\" : \"quz\"\n}")
               (= body "{\n  \"baz\" : \"quz\",\n  \"foo\" : \"bar\"\n}")))))
 
-  (testing "don’t overwrite Content-Type if already set"
+  (testing "CHANGED: don’t overwrite Content-Type if already set - format if :muuntaja/encode is truthy"
     (let [handler (constantly {:status 200 :headers {"Content-Type" "application/json; some-param=some-value"} :body {:foo "bar"}, :muuntaja/encode true})
           response ((wrap-json-response handler) {})
           body (-> response :body slurp)]
       (is (= (get-in response [:headers "Content-Type"]) "application/json; some-param=some-value"))
-      (is (= body "{\"foo\":\"bar\"}")))))
+      (is (= body "{\"foo\":\"bar\"}"))))
+
+  (testing "CHANGED: don’t overwrite Content-Type if already set - don't format if :muuntaja/encode is not set"
+    (let [handler (constantly {:status 200 :headers {"Content-Type" "application/json; some-param=some-value"} :body {:foo "bar"}})
+          response ((wrap-json-response handler) {})
+          body (-> response :body)]
+      (is (= (get-in response [:headers "Content-Type"]) "application/json; some-param=some-value"))
+      (is (= body {:foo "bar"})))))


### PR DESCRIPTION
* **BREAKING**: Changes in special Muuntaja keys in request & response
  * `:muuntaja/format` is not published into request or response
  * `muuntaja.core/disable-request-encoding` helper is removed
  * `muuntaja.core/disable-response-encoding` helper is removed
  * `:muuntaja/encode?` response key (to force encoding) is renamed to `:muuntaja/encode`
* **BREAKING**: if a "Content-Type" header is set in a response, the body will not be encoded, unless `:muuntaja/encode` is set
