### PR TITLE
Fix interceptors namespace link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ There is a more detailed [Ring guide](doc/With-Ring.md) too. See also [differenc
 
 ## Interceptors
 
-See [`muuntaja.interceptor`](https://github.com/metosin/muuntaja/blob/master/src/clj/muuntaja/interceptor.clj).
+See [`muuntaja.interceptor`](https://github.com/metosin/muuntaja/blob/master/modules/muuntaja/src/muuntaja/interceptor.clj).
 
 ## Standalone
 


### PR DESCRIPTION
Link to the interceptors namespace referenced an old repository structure path.