### PR TITLE
Arity 2 encode/decode

### DIFF
--- a/modules/muuntaja/src/muuntaja/core.clj
+++ b/modules/muuntaja/src/muuntaja/core.clj
@@ -72,28 +72,6 @@
   [m] (->> m (options) :formats (map first) (set)))
 
 ;;
-;; encode & decode
-;;
-
-(defn encode
-  "Encode data into the given format. Returns InputStream or throws."
-  ([m format data]
-   (encode m format data (default-charset m)))
-  ([m format data charset]
-   (if-let [encoder (encoder m format)]
-     (encoder data charset)
-     (util/throw! m format "encoder not found for"))))
-
-(defn decode
-  "Decode data into the given format. Returns InputStream or throws."
-  ([m format data]
-   (decode m format data (default-charset m)))
-  ([m format data charset]
-   (if-let [decoder (decoder m format)]
-     (decoder data charset)
-     (util/throw! m format "decoder not found for"))))
-
-;;
 ;; default options
 ;;
 
@@ -497,6 +475,29 @@
 (defmethod print-method ::muuntaja
   [_ ^Writer w]
   (.write w (str "<<Muuntaja>>")))
+
+;;
+;; encode & decode
+;;
+
+(defn encode
+  "Encode data into the given format. Returns InputStream or throws."
+  ([m format data]
+   (encode m format data (default-charset m)))
+  ([m format data charset]
+   (if-let [encoder (encoder m format)]
+     (encoder data charset)
+     (util/throw! m format "encoder not found for"))))
+
+(defn decode
+  "Decode data into the given format. Returns InputStream or throws."
+  ([m format data]
+   (decode m format data (default-charset m)))
+  ([m format data charset]
+   (if-let [decoder (decoder m format)]
+     (decoder data charset)
+     (util/throw! m format "decoder not found for"))))
+
 
 ;;
 ;; options

--- a/modules/muuntaja/src/muuntaja/core.clj
+++ b/modules/muuntaja/src/muuntaja/core.clj
@@ -482,6 +482,8 @@
 
 (defn encode
   "Encode data into the given format. Returns InputStream or throws."
+  ([format data]
+   (encode instance format data))
   ([m format data]
    (encode m format data (default-charset m)))
   ([m format data charset]
@@ -491,6 +493,8 @@
 
 (defn decode
   "Decode data into the given format. Returns InputStream or throws."
+  ([format data]
+   (decode instance format data))
   ([m format data]
    (decode m format data (default-charset m)))
   ([m format data charset]

--- a/test/muuntaja/core_test.clj
+++ b/test/muuntaja/core_test.clj
@@ -53,8 +53,12 @@
 
   (testing "encode & decode"
     (let [data {:kikka 42}]
-      (is (= "{\"kikka\":42}" (slurp (m/encode m "application/json" data))))
-      (is (= data (m/decode m "application/json" (m/encode m "application/json" data))))))
+      (testing "with default instance"
+        (is (= "{\"kikka\":42}" (slurp (m/encode "application/json" data))))
+        (is (= data (m/decode "application/json" (m/encode "application/json" data)))))
+      (testing "with muuntaja instance"
+        (is (= "{\"kikka\":42}" (slurp (m/encode m "application/json" data))))
+        (is (= data (m/decode m "application/json" (m/encode m "application/json" data)))))))
 
   (testing "symmetic encode + decode for all formats"
     (let [data {:kikka 42, :childs {:facts [1.2 true {:so "nested"}]}}]


### PR DESCRIPTION
## Issue
#86

## Outline
Add 2 arity versions of `encode` and `decode` that use the default Muuntaja `instance`

## Tests
Added some basic tests for the 2 arity cases.

The contribution guide mentions `lein midje` but that's not a known task -- I tested with `lein test`.

## Catch
Since 3 arity is already taken, the default instance variants can't take a charset option.