### PR TITLE
m/decode-response-body helper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ sudo: false
 language: clojure
 lein: 2.8.1
 install:
-  - ./scripts/lein-modules install  
+  - ./scripts/lein-modules install
 script:
-  - lein do clean, all test, all check
+  - lein do clean, all test #, all check
 jdk:
   - oraclejdk8
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: clojure
-lein: 2.7.1
+lein: 2.8.1
 install:
   - ./scripts/lein-modules install  
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## UNRELEASED
 
-* don't run tests anymore with Clojure 1.7.0
 * new helper `m/decode-response-body` to return response body, decoded based on response `Content-Type` header. Throws if the body can't be parsed.
 
 ```clj

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UNRELEASED
+
+* don't run tests anymore with Clojure 1.7.0
+
 ## 0.6.2 (9.12.2018)
 
 * Added 2-arity to `encode` & `decode`, using the default instance, fixes [#86](https://github.com/metosin/muuntaja/issues/86), thanks to [valerauko](https://github.com/valerauko).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 ## UNRELEASED
 
 * don't run tests anymore with Clojure 1.7.0
+* new helper `m/decode-response-body` to return response body, decoded based on response `Content-Type` header. Throws if the body can't be parsed.
+
+```clj
+(-> {:headers {"accept" "application/edn"}}
+    ((middleware/wrap-format
+       (constantly {:status 200, :body {:date (Date. 0)}})))
+    (m/decode-response-body))
+; {:date #inst"1970-01-01T00:00:00.000-00:00"}
+```
 
 ## 0.6.2 (9.12.2018)
 

--- a/modules/muuntaja/src/muuntaja/core.clj
+++ b/modules/muuntaja/src/muuntaja/core.clj
@@ -498,9 +498,9 @@
            (-decode-response-body [this response]
              (or
                (if-let [res-fc (-> response :headers (get "Content-Type") -negotiate-content-type)]
-                 (if-let [decode (decoder this (.-format res-fc))]
+                 (if-let [decode (decoder this (:format res-fc))]
                    (try
-                     (decode (:body response) (.-charset res-fc))
+                     (decode (:body response) (:charset res-fc))
                      (catch Exception e
                        (fail-on-response-decode-exception m e res-fc response)))))
                (fail-on-response-decode m response)))))))))

--- a/modules/muuntaja/src/muuntaja/core.clj
+++ b/modules/muuntaja/src/muuntaja/core.clj
@@ -25,6 +25,7 @@
   (negotiate-request-response [this request])
   (format-request [this request])
   (format-response [this request response])
+  (^:private -decode-response-body [this response])
 
   (negotiate-and-format-request [this request]))
 
@@ -136,6 +137,28 @@
        :charset (:charset request-format-and-charset)
        :request request}
       e)))
+
+(defn- fail-on-response-decode-exception [m
+                                          ^Exception e
+                                          ^FormatAndCharset response-format-and-charset
+                                          response]
+  (throw
+    (ex-info
+      (str "Malformed " (:format response-format-and-charset) " response.")
+      {:type :muuntaja/decode
+       :default-format (default-format m)
+       :format (:format response-format-and-charset)
+       :charset (:charset response-format-and-charset)
+       :response response}
+      e)))
+
+(defn- fail-on-response-decode [m response]
+  (throw
+    (ex-info
+      (str "Unknown response Content-Type: " (-> response :headers (get "Content-Type")))
+      {:type :muuntaja/decode
+       :default-format (default-format m)
+       :response response})))
 
 (defn- fail-on-request-charset-negotiation [m]
   (throw
@@ -396,6 +419,13 @@
                                           (decode (:body request) (.-charset req-fc))
                                           (catch Exception e
                                             (fail-on-request-decode-exception m e req-fc res-fc request))))))
+             --decode-response-body (fn [m response ^FormatAndCharset res-fc]
+                                      (if-let [decode (decoder m (if res-fc (.-format res-fc)))]
+                                        (try
+                                          (decode (:body response) (.-charset res-fc))
+                                          (catch Exception e
+                                            (fail-on-response-decode-exception m e res-fc response)))
+                                        (fail-on-response-decode m response)))
              -encode-response? (fn [request response]
                                  (and (or (not (contains? (:headers response) "Content-Type"))
                                           (:muuntaja/encode response))
@@ -468,7 +498,10 @@
                      (assoc $ :muuntaja/response res-fc)
                      (if (not (nil? body))
                        (assoc $ :body-params body)
-                       $))))))))))
+                       $))))
+           (-decode-response-body [this response]
+             (if-let [ct (-> response :headers (get "Content-Type") -negotiate-content-type)]
+               (--decode-response-body this response ct)))))))))
 
 (def instance "the default instance" (create))
 
@@ -492,7 +525,7 @@
      (util/throw! m format "encoder not found for"))))
 
 (defn decode
-  "Decode data into the given format. Returns InputStream or throws."
+  "Decode data into the given format. Returns Clojure Data or throws."
   ([format data]
    (decode instance format data))
   ([m format data]
@@ -502,6 +535,13 @@
      (decoder data charset)
      (util/throw! m format "decoder not found for"))))
 
+(defn decode-response-body
+  "Decode response :body using the format defined by \"Content-Type\" header.
+  Returns Clojure Data or throws."
+  ([response]
+   (-decode-response-body instance response))
+  ([m response]
+   (-decode-response-body m response)))
 
 ;;
 ;; options

--- a/project.clj
+++ b/project.clj
@@ -12,6 +12,7 @@
                          [circleci/clj-yaml "0.5.6"]
                          [clojure-msgpack "1.2.1" :exclusions [org.clojure/clojure]]]
   :dependencies []
+  :source-paths ["modules/muuntaja/src"]
   :plugins [[lein-codox "0.10.5"]]
   :codox {:src-uri "http://github.com/metosin/muuntaja/blob/master/{filepath}#L{line}"
           :output-path "doc"
@@ -22,8 +23,7 @@
   :profiles {:dev {:jvm-opts ^:replace ["-server"]
 
                    ;; all module sources for development
-                   :source-paths ["modules/muuntaja/src"
-                                  "modules/muuntaja-cheshire/src"
+                   :source-paths ["modules/muuntaja-cheshire/src"
                                   "modules/muuntaja-yaml/src"
                                   "modules/muuntaja-msgpack/src"]
 

--- a/project.clj
+++ b/project.clj
@@ -51,6 +51,7 @@
                                   [org.slf4j/slf4j-log4j12 "1.7.25"]
 
                                   [criterium "0.4.4"]]}
+             :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.10 {:dependencies [[org.clojure/clojure "1.10.0-RC4"]]}
              :perf {:jvm-opts ^:replace ["-server"
@@ -61,6 +62,6 @@
                                             "-XX:+PrintCompilation"
                                             "-XX:+UnlockDiagnosticVMOptions"
                                             "-XX:+PrintInlining"]}}
-  :aliases {"all" ["with-profile" "dev:dev,1.8:dev,1.10"]
+  :aliases {"all" ["with-profile" "dev:dev,1.7:dev,1.8"]
             "perf" ["with-profile" "default,dev,perf"]
             "analyze" ["with-profile" "default,dev,analyze"]})

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,6 @@
             :url "http://www.eclipse.org/legal/epl-v20.html"}
   :javac-options ["-Xlint:unchecked" "-target" "1.7" "-source" "1.7"]
   :java-source-paths ["src/java"]
-  :source-paths ["modules/muuntaja/src"]
   :managed-dependencies [[metosin/muuntaja "0.6.2"]
                          [metosin/jsonista "0.2.2"]
                          [com.cognitect/transit-clj "0.8.313"]
@@ -52,9 +51,8 @@
                                   [org.slf4j/slf4j-log4j12 "1.7.25"]
 
                                   [criterium "0.4.4"]]}
-             :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
-             :1.10 {:dependencies [[org.clojure/clojure "1.10.0-alpha5"]]}
+             :1.10 {:dependencies [[org.clojure/clojure "1.10.0-RC4"]]}
              :perf {:jvm-opts ^:replace ["-server"
                                          "-Xmx4096m"
                                          "-Dclojure.compiler.direct-linking=true"]}
@@ -63,6 +61,6 @@
                                             "-XX:+PrintCompilation"
                                             "-XX:+UnlockDiagnosticVMOptions"
                                             "-XX:+PrintInlining"]}}
-  :aliases {"all" ["with-profile" "dev:dev,1.7:dev,1.8:dev,1.10"]
+  :aliases {"all" ["with-profile" "dev:dev,1.8:dev,1.10"]
             "perf" ["with-profile" "default,dev,perf"]
             "analyze" ["with-profile" "default,dev,analyze"]})

--- a/test/muuntaja/middleware_test.clj
+++ b/test/muuntaja/middleware_test.clj
@@ -99,6 +99,16 @@
                     #"Malformed application/json response"
                     (m/decode-response-body (app {}))))))
 
+          (testing "when no content-type is found"
+            (let [app (middleware/wrap-format
+                        (constantly
+                          {:status 200
+                           :body (m/encode "application/edn" {:kikka 123})}))]
+              (is (thrown-with-msg?
+                    Exception
+                    #"No Content-Type found"
+                    (m/decode-response-body (app {}))))))
+
           (testing "when no decoder is found"
             (let [app (middleware/wrap-format
                         (constantly


### PR DESCRIPTION
* don't run tests anymore with Clojure 1.7.0
* new helper `m/decode-response-body` to return response body, decoded based on response `Content-Type` header. Throws if the body can't be parsed.

```clj
(-> {:headers {"accept" "application/edn"}}
    ((middleware/wrap-format
       (constantly {:status 200, :body {:date (Date. 0)}})))
    (m/decode-response-body))
; {:date #inst"1970-01-01T00:00:00.000-00:00"}
```
