### PR TITLE
Update README - change cljdoc.xyz domain to cljdoc.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ but a complete rewrite ([and up to 30x faster](doc/Performance.md)).
 
 * [Muuntaja, a boring library everyone should use](https://www.metosin.fi/blog/muuntaja/)
 
-Check [the docs on cljdoc.xyz](https://cljdoc.xyz/jump/release/metosin/muuntaja)
+Check [the docs on cljdoc.org](https://cljdoc.org/d/metosin/muuntaja)
 for detailed API documentation as well as more guides on how to use Muuntaja.
 
 ## Latest version


### PR DESCRIPTION
Since last October, [the domain has been migrated to cljdoc.org](https://github.com/cljdoc/cljdoc/blob/e8f01d6865cfa123bf792144a1c1908c60daeb77/doc/updates/0006-cljdoc-october.md#things-that-have-have-been-shipped-in-october). The updated link points to the latest version of the documentation, which is https://cljdoc.org/d/metosin/muuntaja/0.6.4/doc/readme as today.