### PR TITLE
Change ->> to some->> to fix handler chaining

### DIFF
--- a/modules/muuntaja/src/muuntaja/middleware.clj
+++ b/modules/muuntaja/src/muuntaja/middleware.clj
@@ -70,7 +70,7 @@
      (fn
        ([request]
         (let [req (m/negotiate-and-format-request m request)]
-          (->> (handler req) (m/format-response m req))))
+          (some->> (handler req) (m/format-response m req))))
        ([request respond raise]
         (let [req (m/negotiate-and-format-request m request)]
           (handler req #(respond (m/format-response m req %)) raise)))))))
@@ -129,6 +129,6 @@
    (let [m (m/create prototype)]
      (fn
        ([request]
-        (->> (handler request) (m/format-response m request)))
+        (some->> (handler request) (m/format-response m request)))
        ([request respond raise]
         (handler request #(respond (m/format-response m request %)) raise))))))


### PR DESCRIPTION
Compojure and friends use the convention that when a handler returns nil it means the request is not for this handler. Muuntaja middleware were not preserving `nil`s.