### PR TITLE
Support use in a http client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ pom.xml*
 .lein-repl-history
 .nrepl-port
 \#*\#
+pom.properties
+leiningen.core.classpath.extract-native-dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
+## unreleased
+**[compare](https://github.com/metosin/muuntaja/compare/0.6.6...master)**
+
+* Fix case insensitive header comparison: In http-1.1, headers are to be compared case insensitive, and in http-2, headers are to be lower-cased before encoding. Thus, retrieving "Content-Type" in a case-sensitive fashion is likely to fail.
+
 ## 0.6.6 (2019-11-07)
 
-**[compare](https://github.com/metosin/muuntaja/compare/0.6.5...master)**
+**[compare](https://github.com/metosin/muuntaja/compare/0.6.5...0.6.6)**
 
 * Fix handler chaining when `nil` is returned from handler.
 
 ## 0.6.5 (2019-10-07)
 
-**[compare](https://github.com/metosin/muuntaja/compare/0.6.4...master)**
+**[compare](https://github.com/metosin/muuntaja/compare/0.6.4...0.6.5)**
 
 * Update deps:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,15 +10,15 @@ Please file bug reports and feature requests to https://github.com/metosin/muunt
 * Create a topic branch from where you want to base your work (usually the master branch)
 * Check the formatting rules from existing code (no trailing whitepace, mostly default indentation)
 * Ensure any new code is well-tested, and if possible, any issue fixed is covered by one or more new tests
-* Verify that all tests pass using ```lein midje```
+* Verify that all tests pass using ```lein test```
 * Push your code to your fork of the repository
 * Make a Pull Request
 
 Installing jars and changing of version numbers can be done with the following scripts:
 
 ```sh
-./script/set-version 1.0.0
-./script/lein-modules install
+./scripts/set-version 1.0.0
+./scripts/lein-modules install
 ```
 
 

--- a/modules/muuntaja-cheshire/project.clj
+++ b/modules/muuntaja-cheshire/project.clj
@@ -1,4 +1,4 @@
-(defproject metosin/muuntaja-cheshire "0.6.6"
+(defproject metosin/muuntaja-cheshire "0.0.0" ;; use lein v
   :description "Cheshire/JSON format for Muuntaja"
   :url "https://github.com/metosin/muuntaja"
   :license {:name "Eclipse Public License"
@@ -6,8 +6,12 @@
   :scm {:name "git"
         :url "https://github.com/metosin/muuntaja"
         :dir "../.."}
-  :plugins [[lein-parent "0.3.2"]]
+  :plugins [[lein-parent "0.3.2"]
+            [com.roomkey/lein-v "7.0.0"]]
+  :middleware [leiningen.v/version-from-scm
+               leiningen.v/dependency-version-from-scm
+               leiningen.v/add-workspace-data]
   :parent-project {:path "../../project.clj"
-                   :inherit [:deploy-repositories :managed-dependencies]}
+                   :inherit [:deploy-repositories]}
   :dependencies [[metosin/muuntaja]
-                 [cheshire]])
+                 [cheshire "5.9.0"]])

--- a/modules/muuntaja-msgpack/project.clj
+++ b/modules/muuntaja-msgpack/project.clj
@@ -1,4 +1,4 @@
-(defproject metosin/muuntaja-msgpack "0.6.6"
+(defproject metosin/muuntaja-msgpack "0.0.0" ;; use lein v
   :description "Messagepack format for Muuntaja"
   :url "https://github.com/metosin/muuntaja"
   :license {:name "Eclipse Public License"
@@ -6,8 +6,12 @@
   :scm {:name "git"
         :url "https://github.com/metosin/muuntaja"
         :dir "../.."}
-  :plugins [[lein-parent "0.3.2"]]
+  :plugins [[lein-parent "0.3.2"]
+            [com.roomkey/lein-v "7.0.0"]]
+  :middleware [leiningen.v/version-from-scm
+               leiningen.v/dependency-version-from-scm
+               leiningen.v/add-workspace-data]
   :parent-project {:path "../../project.clj"
-                   :inherit [:deploy-repositories :managed-dependencies]}
+                   :inherit [:deploy-repositories]}
   :dependencies [[metosin/muuntaja]
-                 [clojure-msgpack]])
+                 [clojure-msgpack "1.2.1" :exclusions [org.clojure/clojure]]])

--- a/modules/muuntaja-yaml/project.clj
+++ b/modules/muuntaja-yaml/project.clj
@@ -1,4 +1,4 @@
-(defproject metosin/muuntaja-yaml "0.6.6"
+(defproject metosin/muuntaja-yaml "0.0.0" ;; use lein v
   :description "YAML format for Muuntaja"
   :url "https://github.com/metosin/muuntaja"
   :license {:name "Eclipse Public License"
@@ -6,8 +6,12 @@
   :scm {:name "git"
         :url "https://github.com/metosin/muuntaja"
         :dir "../.."}
-  :plugins [[lein-parent "0.3.2"]]
+  :plugins [[lein-parent "0.3.2"]
+            [com.roomkey/lein-v "7.0.0"]]
+  :middleware [leiningen.v/version-from-scm
+               leiningen.v/dependency-version-from-scm
+               leiningen.v/add-workspace-data]
   :parent-project {:path "../../project.clj"
-                   :inherit [:deploy-repositories :managed-dependencies]}
+                   :inherit [:deploy-repositories]}
   :dependencies [[metosin/muuntaja]
-                 [clj-commons/clj-yaml]])
+                 [clj-commons/clj-yaml "0.7.0"]])

--- a/modules/muuntaja/project.clj
+++ b/modules/muuntaja/project.clj
@@ -13,5 +13,6 @@
                leiningen.v/add-workspace-data]
   :parent-project {:path "../../project.clj"
                    :inherit [:deploy-repositories]}
-  :dependencies [[metosin/jsonista "0.2.5"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [metosin/jsonista "0.2.5"]
                  [com.cognitect/transit-clj "0.8.319"]])

--- a/modules/muuntaja/project.clj
+++ b/modules/muuntaja/project.clj
@@ -1,4 +1,4 @@
-(defproject metosin/muuntaja "0.6.6"
+(defproject metosin/muuntaja "0.0.0"                        ;; use lein v
   :description "Clojure library for format encoding, decoding and content-negotiation"
   :url "https://github.com/metosin/muuntaja"
   :license {:name "Eclipse Public License"
@@ -6,8 +6,12 @@
   :scm {:name "git"
         :url "https://github.com/metosin/muuntaja"
         :dir "../.."}
-  :plugins [[lein-parent "0.3.2"]]
+  :plugins [[lein-parent "0.3.2"]
+            [com.roomkey/lein-v "7.0.0"]]
+  :middleware [leiningen.v/version-from-scm
+               leiningen.v/dependency-version-from-scm
+               leiningen.v/add-workspace-data]
   :parent-project {:path "../../project.clj"
-                   :inherit [:deploy-repositories :managed-dependencies]}
-  :dependencies [[metosin/jsonista]
-                 [com.cognitect/transit-clj]])
+                   :inherit [:deploy-repositories]}
+  :dependencies [[metosin/jsonista "0.2.5"]
+                 [com.cognitect/transit-clj "0.8.319"]])

--- a/modules/muuntaja/src/muuntaja/core.clj
+++ b/modules/muuntaja/src/muuntaja/core.clj
@@ -519,8 +519,10 @@
                    (try
                      (decode (:body response) (:charset res-fc))
                      (catch Exception e
-                       (fail-on-response-decode-exception m e res-fc response)))))
-               (fail-on-response-decode m response)))))))))
+                       (fail-on-response-decode-exception m e res-fc response)))
+                   (fail-on-response-decode m response))
+                 (fail-on-response-decode m response))
+               ))))))))
 
 (def instance "the default instance" (create))
 

--- a/project.clj
+++ b/project.clj
@@ -1,70 +1,69 @@
-(defproject metosin/muuntaja "0.6.6"
+(defproject metosin/muuntaja "0.0.0"
   :description "Clojure library for format encoding, decoding and content-negotiation"
   :url "https://github.com/metosin/muuntaja"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v20.html"}
   :javac-options ["-Xlint:unchecked" "-target" "1.7" "-source" "1.7"]
   :java-source-paths ["src/java"]
-  :managed-dependencies [[metosin/muuntaja "0.6.6"]
-                         [metosin/jsonista "0.2.5"]
-                         [com.cognitect/transit-clj "0.8.319"]
-                         [cheshire "5.9.0"]
-                         [clj-commons/clj-yaml "0.7.0"]
-                         [clojure-msgpack "1.2.1" :exclusions [org.clojure/clojure]]]
   :dependencies []
   :source-paths ["modules/muuntaja/src"]
-  :plugins [[lein-codox "0.10.7"]]
-  :codox {:src-uri "http://github.com/metosin/muuntaja/blob/master/{filepath}#L{line}"
+  :plugins [[lein-codox "0.10.7"]
+            [com.roomkey/lein-v "7.0.0"]]
+  :middleware [leiningen.v/version-from-scm
+               leiningen.v/dependency-version-from-scm
+               leiningen.v/add-workspace-data]
+
+  :codox {:src-uri     "http://github.com/metosin/muuntaja/blob/master/{filepath}#L{line}"
           :output-path "doc"
-          :metadata {:doc/format :markdown}}
+          :metadata    {:doc/format :markdown}}
   :scm {:name "git"
-        :url "https://github.com/metosin/muuntaja"}
+        :url  "https://github.com/metosin/muuntaja"}
   :deploy-repositories [["releases" :clojars]]
-  :profiles {:dev {:jvm-opts ^:replace ["-server"]
+  :profiles {:dev     {:jvm-opts     ^:replace ["-server"]
 
-                   ;; all module sources for development
-                   :source-paths ["modules/muuntaja-cheshire/src"
-                                  "modules/muuntaja-yaml/src"
-                                  "modules/muuntaja-msgpack/src"]
+                       ;; all module sources for development
+                       :source-paths ["modules/muuntaja-cheshire/src"
+                                      "modules/muuntaja-yaml/src"
+                                      "modules/muuntaja-msgpack/src"]
 
-                   :dependencies [[org.clojure/clojure "1.10.1"]
-                                  [ring/ring-core "1.7.1"]
-                                  [ring-middleware-format "0.7.4"]
-                                  [ring-transit "0.1.6"]
-                                  [ring/ring-json "0.5.0"]
+                       :dependencies [[org.clojure/clojure "1.10.1"]
+                                      [ring/ring-core "1.7.1"]
+                                      [ring-middleware-format "0.7.4"]
+                                      [ring-transit "0.1.6"]
+                                      [ring/ring-json "0.5.0"]
 
-                                  ;; modules
-                                  [metosin/muuntaja "0.6.6"]
-                                  [metosin/muuntaja-cheshire "0.6.6"]
-                                  [metosin/muuntaja-msgpack "0.6.6"]
-                                  [metosin/muuntaja-yaml "0.6.6"]
+                                      ;; modules
+                                      [metosin/muuntaja nil]
+                                      [metosin/muuntaja-cheshire nil]
+                                      [metosin/muuntaja-msgpack nil]
+                                      [metosin/muuntaja-yaml nil]
 
-                                  ;; correct jackson
-                                  [com.fasterxml.jackson.core/jackson-databind "2.10.0"]
+                                      ;; correct jackson
+                                      [com.fasterxml.jackson.core/jackson-databind "2.10.0"]
 
-                                  ;; Sieppari
-                                  [metosin/sieppari "0.0.0-alpha5"]
+                                      ;; Sieppari
+                                      [metosin/sieppari "0.0.0-alpha5"]
 
-                                  ;; Pedestal
-                                  [org.clojure/core.async "0.4.500" :exclusions [org.clojure/tools.reader]]
-                                  [io.pedestal/pedestal.service "0.5.7" :exclusions [org.clojure/tools.reader
-                                                                                     org.clojure/core.async
-                                                                                     org.clojure/core.memoize]]
-                                  [javax.servlet/javax.servlet-api "4.0.1"]
-                                  [org.slf4j/slf4j-log4j12 "1.7.29"]
+                                      ;; Pedestal
+                                      [org.clojure/core.async "0.4.500" :exclusions [org.clojure/tools.reader]]
+                                      [io.pedestal/pedestal.service "0.5.7" :exclusions [org.clojure/tools.reader
+                                                                                         org.clojure/core.async
+                                                                                         org.clojure/core.memoize]]
+                                      [javax.servlet/javax.servlet-api "4.0.1"]
+                                      [org.slf4j/slf4j-log4j12 "1.7.29"]
 
-                                  [criterium "0.4.5"]]}
-             :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
-             :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
-             :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
-             :perf {:jvm-opts ^:replace ["-server"
-                                         "-Xmx4096m"
-                                         "-Dclojure.compiler.direct-linking=true"]}
+                                      [criterium "0.4.5"]]}
+             :1.7     {:dependencies [[org.clojure/clojure "1.7.0"]]}
+             :1.8     {:dependencies [[org.clojure/clojure "1.8.0"]]}
+             :1.9     {:dependencies [[org.clojure/clojure "1.9.0"]]}
+             :perf    {:jvm-opts ^:replace ["-server"
+                                            "-Xmx4096m"
+                                            "-Dclojure.compiler.direct-linking=true"]}
              :analyze {:jvm-opts ^:replace ["-server"
                                             "-Dclojure.compiler.direct-linking=true"
                                             "-XX:+PrintCompilation"
                                             "-XX:+UnlockDiagnosticVMOptions"
                                             "-XX:+PrintInlining"]}}
-  :aliases {"all" ["with-profile" "dev:dev,1.7:dev,1.8:dev,1.9"]
-            "perf" ["with-profile" "default,dev,perf"]
+  :aliases {"all"     ["with-profile" "dev:dev,1.7:dev,1.8:dev,1.9"]
+            "perf"    ["with-profile" "default,dev,perf"]
             "analyze" ["with-profile" "default,dev,analyze"]})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject metosin/muuntaja "0.0.0"
+(defproject metosin/muuntaja-parent "0.0.0"
   :description "Clojure library for format encoding, decoding and content-negotiation"
   :url "https://github.com/metosin/muuntaja"
   :license {:name "Eclipse Public License"
@@ -52,7 +52,10 @@
                                       [javax.servlet/javax.servlet-api "4.0.1"]
                                       [org.slf4j/slf4j-log4j12 "1.7.29"]
 
-                                      [criterium "0.4.5"]]}
+                                      [criterium "0.4.5"]
+
+                                      [metosin/jsonista "0.2.5"]
+                                      ]}
              :1.7     {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8     {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.9     {:dependencies [[org.clojure/clojure "1.9.0"]]}

--- a/scripts/set-version
+++ b/scripts/set-version
@@ -1,8 +1,0 @@
-#!/bin/zsh
-
-ext="sedbak$$"
-
-find . -name project.clj -exec sed -i.$ext "s/\[metosin\/muuntaja\(.*\) \".*\"\]/[metosin\/muuntaja\1 \"$1\"\]/g" '{}' \;
-find . -name project.clj -exec sed -i.$ext "s/defproject metosin\/muuntaja\(.*\) \".*\"/defproject metosin\/muuntaja\1 \"$1\"/g" '{}' \;
-sed -i.$ext "s/\[metosin\/muuntaja\(.*\) \".*\"\]/[metosin\/muuntaja\1 \"$1\"\]/g" **/*.md
-find . -name "*.$ext" -exec rm '{}' \;

--- a/test/muuntaja/ring_json/json_test.clj
+++ b/test/muuntaja/ring_json/json_test.clj
@@ -253,15 +253,15 @@
               (= body "{\n  \"baz\" : \"quz\",\n  \"foo\" : \"bar\"\n}")))))
 
   (testing "CHANGED: don’t overwrite Content-Type if already set - format if :muuntaja/encode is truthy"
-    (let [handler (constantly {:status 200 :headers {"Content-Type" "application/json; some-param=some-value"} :body {:foo "bar"}, :muuntaja/encode true})
+    (let [handler (constantly {:status 200 :headers {"content-type" "application/json; some-param=some-value"} :body {:foo "bar"}, :muuntaja/encode true})
           response ((wrap-json-response handler) {})
           body (-> response :body slurp)]
-      (is (= (get-in response [:headers "Content-Type"]) "application/json; some-param=some-value"))
+      (is (= (m/header "Content-Type" response) "application/json; some-param=some-value"))
       (is (= body "{\"foo\":\"bar\"}"))))
 
   (testing "CHANGED: don’t overwrite Content-Type if already set - don't format if :muuntaja/encode is not set"
-    (let [handler (constantly {:status 200 :headers {"Content-Type" "application/json; some-param=some-value"} :body {:foo "bar"}})
+    (let [handler (constantly {:status 200 :headers {"coNTENt-Type" "application/json; some-param=some-value"} :body {:foo "bar"}})
           response ((wrap-json-response handler) {})
           body (-> response :body)]
-      (is (= (get-in response [:headers "Content-Type"]) "application/json; some-param=some-value"))
+      (is (= (m/header "Content-Type" response) "application/json; some-param=some-value"))
       (is (= body {:foo "bar"})))))


### PR DESCRIPTION
Hi @ikitommi, hope you're fine after ClojureD.

Got a PR for you, as I'm trying to build production code on top of a hato/muuntaja combination for (new) http client libs.

As stated in #101 , content negotiation is not only a server-side issue, but also a http client side one. As muuntaja looks very promising (thanks for that), I made changes to use it in my [hato fork](https://github.com/gorillalabs/hato) (an http client based upon the 'new' jdk11 http client).

- One problem I stumbled upon was #99 .
- Another one was a failure when reading empty bodies. That should be ok if format permits (e.g. an empty JSON body should return a `nil` `:body`).

It would be very kind to consider the changes. However, I stumbled over some minor difficulties developing the stuff, so besides the necessary changes to the code I also altered stuff in [CONTRIBUTING.md](https://github.com/gorillalabs/muuntaja/blob/feature/client/CONTRIBUTING.md), which I believe just wasn't tested/updated properly before.

And, last but not least, I switched to 'lein v' instead of hardcoded versions to keep things consistent between the modules more easily. It made my life easier, but you might not like it.

I kept the commits clean, so you can basically cherry-pick the changes or take the whole PR. Up to you.

Regards,

Chris