### PR TITLE
modules: Inherit :dev profile

### DIFF
--- a/modules/muuntaja-cheshire/project.clj
+++ b/modules/muuntaja-cheshire/project.clj
@@ -8,6 +8,8 @@
         :dir "../.."}
   :plugins [[lein-parent "0.3.2"]]
   :parent-project {:path "../../project.clj"
-                   :inherit [:deploy-repositories :managed-dependencies]}
+                   :inherit [:deploy-repositories
+                             :managed-dependencies
+                             :profiles [:dev]]}
   :dependencies [[metosin/muuntaja]
                  [cheshire]])

--- a/modules/muuntaja-msgpack/project.clj
+++ b/modules/muuntaja-msgpack/project.clj
@@ -8,6 +8,8 @@
         :dir "../.."}
   :plugins [[lein-parent "0.3.2"]]
   :parent-project {:path "../../project.clj"
-                   :inherit [:deploy-repositories :managed-dependencies]}
+                   :inherit [:deploy-repositories
+                             :managed-dependencies
+                             :profiles [:dev]]}
   :dependencies [[metosin/muuntaja]
                  [clojure-msgpack]])

--- a/modules/muuntaja-yaml/project.clj
+++ b/modules/muuntaja-yaml/project.clj
@@ -8,6 +8,8 @@
         :dir "../.."}
   :plugins [[lein-parent "0.3.2"]]
   :parent-project {:path "../../project.clj"
-                   :inherit [:deploy-repositories :managed-dependencies]}
+                   :inherit [:deploy-repositories
+                             :managed-dependencies
+                             :profiles [:dev]]}
   :dependencies [[metosin/muuntaja]
                  [clj-commons/clj-yaml]])

--- a/modules/muuntaja/project.clj
+++ b/modules/muuntaja/project.clj
@@ -8,6 +8,8 @@
         :dir "../.."}
   :plugins [[lein-parent "0.3.2"]]
   :parent-project {:path "../../project.clj"
-                   :inherit [:deploy-repositories :managed-dependencies]}
+                   :inherit [:deploy-repositories
+                             :managed-dependencies
+                             :profiles [:dev]]}
   :dependencies [[metosin/jsonista]
                  [com.cognitect/transit-clj]])


### PR DESCRIPTION
when running `lein repl` from the muuntaja module there was the following error

```sh
Error: Could not find or load main class clojure.main
Caused by: java.lang.ClassNotFoundException: clojure.main
Subprocess failed (exit code: 1)
```

This error means that the Clojure jar was not in the classpath. Inheriting the :dev profile as documented by [lein-parent](https://github.com/achin/lein-parent#usage) fixes the problem.

Fixes #108