### PR TITLE
Support ‘application/x-www-form-urlencoded’

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ but a complete rewrite ([and up to 30x faster](doc/Performance.md)).
 
 ## Modules
 
-* `metosin/muuntaja` - the core abstractions + [Jsonista JSON](https://github.com/metosin/jsonista), EDN and Transit formats
+* `metosin/muuntaja` - the core abstractions + [Jsonista JSON](https://github.com/metosin/jsonista), `application/x-www-form-urlencoded`, EDN and Transit formats
 * `metosin/muuntaja-cheshire` - optional [Cheshire JSON](https://github.com/dakrone/cheshire) format
 * `metosin/muuntaja-msgpack` - Messagepack format
 * `metosin/muuntaja-yaml` - YAML format

--- a/modules/muuntaja/project.clj
+++ b/modules/muuntaja/project.clj
@@ -9,5 +9,6 @@
   :plugins [[lein-parent "0.3.2"]]
   :parent-project {:path "../../project.clj"
                    :inherit [:deploy-repositories :managed-dependencies]}
-  :dependencies [[metosin/jsonista]
+  :dependencies [[ring/ring-codec]
+                 [metosin/jsonista]
                  [com.cognitect/transit-clj]])

--- a/modules/muuntaja/src/muuntaja/core.clj
+++ b/modules/muuntaja/src/muuntaja/core.clj
@@ -6,6 +6,7 @@
             [muuntaja.protocols :as protocols]
             [muuntaja.format.core :as core]
             [muuntaja.format.json :as json-format]
+            [muuntaja.format.form :as form-format]
             [muuntaja.format.edn :as edn-format]
             [muuntaja.format.transit :as transit-format]
             [clojure.set :as set])
@@ -116,6 +117,7 @@
    :default-format "application/json"
    :formats {"application/json" json-format/format
              "application/edn" edn-format/format
+             "application/x-www-form-urlencoded" form-format/format
              "application/transit+json" transit-format/json-format
              "application/transit+msgpack" transit-format/msgpack-format}})
 

--- a/modules/muuntaja/src/muuntaja/format/form.clj
+++ b/modules/muuntaja/src/muuntaja/format/form.clj
@@ -1,0 +1,40 @@
+(ns muuntaja.format.form
+  (:refer-clojure :exclude [format])
+  (:require [muuntaja.format.core :as core]
+            [ring.util.codec :as codec])
+  (:import (java.io OutputStream)))
+
+(defn decoder
+  "Create a decoder which converts a ‘application/x-www-form-urlencoded’
+  representation into clojure data."
+  [_]
+  (reify
+    core/Decode
+    (decode [_ data charset]
+      (let [input (slurp data :encoding charset)]
+        (codec/form-decode input charset)))))
+
+(defn encoder
+  "Create an encoder which converts clojure data into an
+  ‘application/x-www-form-urlencoded’ representation."
+  [_]
+  (reify
+    core/EncodeToBytes
+    (encode-to-bytes [_ data charset]
+      (let [encoded (codec/form-encode data charset)]
+        (.getBytes encoded ^String charset)))
+
+    core/EncodeToOutputStream
+    (encode-to-output-stream [_ data charset]
+      (fn [^OutputStream output-stream]
+        (let [encoded (codec/form-encode data charset)
+              bytes (.getBytes encoded ^String charset)]
+          (.write output-stream bytes))))))
+
+(def format
+  "Formatter handling ‘application/x-www-form-urlencoded’ representations
+  with the `ring.util.codec` library."
+  (core/map->Format
+    {:name "application/x-www-form-urlencoded"
+     :decoder [decoder]
+     :encoder [encoder]}))

--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,7 @@
   :javac-options ["-Xlint:unchecked" "-target" "1.7" "-source" "1.7"]
   :java-source-paths ["src/java"]
   :managed-dependencies [[metosin/muuntaja "0.6.6"]
+                         [ring/ring-codec "1.1.2"]
                          [metosin/jsonista "0.2.5"]
                          [com.cognitect/transit-clj "0.8.319"]
                          [cheshire "5.9.0"]

--- a/test/muuntaja/core_test.clj
+++ b/test/muuntaja/core_test.clj
@@ -268,6 +268,19 @@
                   [:formats "application/jsonz" :decoder-opts]
                   {:keywords? false})))))))
 
+(deftest form-data
+  (testing "basic form encoding"
+    (let [data {:kikka 42, :childs ['not "so" "nested"]}
+          format "application/x-www-form-urlencoded"]
+      (is (= "kikka=42&childs=not&childs=so&childs=nested"
+             (slurp (m/encode m format data))))))
+
+  (testing "basic form decoding"
+    (let [data "kikka=42&childs=not&childs=so&childs=nested=but+messed+up"
+          format "application/x-www-form-urlencoded"]
+      (is (= {"kikka" "42", "childs" ["not" "so" "nested=but messed up"]}
+             (m/decode m format data))))))
+
 (deftest cheshire-json-options
   (testing "pre 0.6.0 options fail at creation time"
     (testing ":bigdecimals?"


### PR DESCRIPTION
This implements encoding/decoding for the `application/x-www-form-urlencoded` media-type which is the default format sent by browsers when submitting HTML forms using the POSTmethod.

The implementation relies on the `ring.util.codec` library to perform both the encoding and decoding. This is the same library that is used by the `ring.middleware.params` alternative solution for handling both query params and body params encoded with the `application/x-www-form-urlencoded` media-type.

This fixes #27.