### PR TITLE
Add README example for camelCase encoding JSON response

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Explicit Muuntaja instance with camelCase encode-key-fn:
       {:encode-key-fn csk/->camelCase})))
 
 (->> {:some-property "some-value"}
-     (m/encode mun "application/json")
+     (m/encode m "application/json")
      slurp)
 ; => "{\":someProperty\":\"some-value\"}"
 ```


### PR DESCRIPTION
I found it difficult to figure out how to do this fairly simple change. I've added an example to the README which can hopefully help future users.