### PR TITLE
Add charred json formatter module

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,9 +17,21 @@ Please file bug reports and feature requests to https://github.com/metosin/muunt
 Installing jars and changing of version numbers can be done with the following scripts:
 
 ```sh
-./script/set-version 1.0.0
-./script/lein-modules install
+./scripts/set-version 1.0.0
+./scripts/lein-modules install
 ```
+
+## Running locally
+
+You can run the a local nREPL with the following:
+
+```sh
+lein with-profile default,dev repl
+```
+
+Note: make sure you install modules first if you've made any changes you want reflected. See above.
+
+Tests can be ran standalone via `lein test`.
 
 
 ## Commit messages

--- a/modules/muuntaja-charred/project.clj
+++ b/modules/muuntaja-charred/project.clj
@@ -1,4 +1,4 @@
-(defproject metosin/muuntaja-charred "0.6.8"
+(defproject fi.metosin/muuntaja-charred "0.6.8"
   :description "Charred/JSON format for Muuntaja"
   :url "https://github.com/metosin/muuntaja"
   :license {:name "Eclipse Public License"

--- a/modules/muuntaja-charred/project.clj
+++ b/modules/muuntaja-charred/project.clj
@@ -1,0 +1,15 @@
+(defproject metosin/muuntaja-charred "0.6.8"
+  :description "Charred/JSON format for Muuntaja"
+  :url "https://github.com/metosin/muuntaja"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :scm {:name "git"
+        :url "https://github.com/metosin/muuntaja"
+        :dir "../.."}
+  :plugins [[lein-parent "0.3.2"]]
+  :parent-project {:path "../../project.clj"
+                   :inherit [:deploy-repositories
+                             :managed-dependencies
+                             :profiles [:dev]]}
+  :dependencies [[metosin/muuntaja]
+                 [charred]])

--- a/modules/muuntaja-charred/project.clj
+++ b/modules/muuntaja-charred/project.clj
@@ -12,4 +12,4 @@
                              :managed-dependencies
                              :profiles [:dev]]}
   :dependencies [[metosin/muuntaja]
-                 [charred]])
+                 [com.cnuernber/charred]])

--- a/modules/muuntaja-charred/src/muuntaja/format/charred.clj
+++ b/modules/muuntaja-charred/src/muuntaja/format/charred.clj
@@ -43,4 +43,4 @@
     {:name    "application/json"
      :decoder [decoder {:key-fn keyword
                         :async? false}]
-     :encoder [encoder]}))
+     :encoder [encoder {:escape-unicode false}]}))

--- a/modules/muuntaja-charred/src/muuntaja/format/charred.clj
+++ b/modules/muuntaja-charred/src/muuntaja/format/charred.clj
@@ -1,0 +1,46 @@
+(ns muuntaja.format.charred
+  (:refer-clojure :exclude [format])
+  (:require
+    [charred.api :as charred]
+    [muuntaja.format.core :as core])
+  (:import
+    [charred JSONReader JSONWriter]
+    [java.io InputStream InputStreamReader OutputStream OutputStreamWriter]
+    [org.apache.commons.io.output ByteArrayOutputStream]))
+
+(defn decoder [options]
+  (let [json-reader-fn (charred/json-reader-fn options)]
+    (reify
+      core/Decode
+      (decode [_ data charset]
+        (let [[^JSONReader json-rdr finalize-fn] (json-reader-fn)
+              input (InputStreamReader. ^InputStream data ^String charset)]
+          (with-open [rdr (charred/reader->char-reader input options)]
+            (.beginParse json-rdr rdr)
+            (finalize-fn (.readObject json-rdr))))))))
+
+(defn encoder [options]
+  (let [json-writer-fn (charred/json-writer-fn options)]
+    (reify
+      core/EncodeToBytes
+      (encode-to-bytes [_ data charset]
+        (let [output-stream (ByteArrayOutputStream.)
+              output        (OutputStreamWriter. output-stream ^String charset)]
+          (with-open [^JSONWriter writer (json-writer-fn output)]
+            (.writeObject writer data))
+          (.toByteArray output-stream)))
+
+      core/EncodeToOutputStream
+      (encode-to-output-stream [_ data charset]
+        (fn [^OutputStream output-stream]
+          (let [output (OutputStreamWriter. output-stream ^String charset)]
+            (with-open [^JSONWriter writer (json-writer-fn output)]
+              (.writeObject writer data))
+            (.flush output-stream)))))))
+
+(def format
+  (core/map->Format
+    {:name    "application/json"
+     :decoder [decoder {:key-fn keyword
+                        :async? false}]
+     :encoder [encoder]}))

--- a/project.clj
+++ b/project.clj
@@ -9,6 +9,7 @@
                          [com.cognitect/transit-clj "1.0.324"]
                          [com.cnuernber/charred "1.033"]
                          [cheshire "5.10.0"]
+                         [com.cnuernber/charred "1.033"]
                          [clj-commons/clj-yaml "0.7.106"]
                          [clojure-msgpack "1.2.1" :exclusions [org.clojure/clojure]]]
   :source-paths ["modules/muuntaja/src"]

--- a/project.clj
+++ b/project.clj
@@ -7,6 +7,7 @@
                          [ring/ring-codec "1.1.2"]
                          [metosin/jsonista "0.3.1"]
                          [com.cognitect/transit-clj "1.0.324"]
+                         [com.cnuernber/charred "1.033"]
                          [cheshire "5.10.0"]
                          [clj-commons/clj-yaml "0.7.106"]
                          [clojure-msgpack "1.2.1" :exclusions [org.clojure/clojure]]]
@@ -21,7 +22,8 @@
   :profiles {:dev {:jvm-opts ^:replace ["-server"]
 
                    ;; all module sources for development
-                   :source-paths ["modules/muuntaja-cheshire/src"
+                   :source-paths ["modules/muuntaja-charred/src"
+                                  "modules/muuntaja-cheshire/src"
                                   "modules/muuntaja-form/src"
                                   "modules/muuntaja-yaml/src"
                                   "modules/muuntaja-msgpack/src"]
@@ -35,6 +37,7 @@
                                   ;; modules
                                   [metosin/muuntaja "0.6.8"]
                                   [metosin/muuntaja-form "0.6.8"]
+                                  [metosin/muuntaja-charred "0.6.8"]
                                   [metosin/muuntaja-cheshire "0.6.8"]
                                   [metosin/muuntaja-msgpack "0.6.8"]
                                   [metosin/muuntaja-yaml "0.6.8"]

--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,6 @@
                          [com.cognitect/transit-clj "1.0.324"]
                          [com.cnuernber/charred "1.033"]
                          [cheshire "5.10.0"]
-                         [com.cnuernber/charred "1.033"]
                          [clj-commons/clj-yaml "0.7.106"]
                          [clojure-msgpack "1.2.1" :exclusions [org.clojure/clojure]]]
   :source-paths ["modules/muuntaja/src"]
@@ -30,6 +29,7 @@
                                   "modules/muuntaja-msgpack/src"]
 
                    :dependencies [[org.clojure/clojure "1.10.2"]
+                                  [com.cnuernber/charred "1.033"]
                                   [ring/ring-core "1.9.0"]
                                   [ring-middleware-format "0.7.4"]
                                   [ring-transit "0.1.6"]
@@ -38,7 +38,7 @@
                                   ;; modules
                                   [metosin/muuntaja "0.6.8"]
                                   [metosin/muuntaja-form "0.6.8"]
-                                  [metosin/muuntaja-charred "0.6.8"]
+;;                                  [fi.metosin/muuntaja-charred "0.6.8"] ;; not yet released
                                   [metosin/muuntaja-cheshire "0.6.8"]
                                   [metosin/muuntaja-msgpack "0.6.8"]
                                   [metosin/muuntaja-yaml "0.6.8"]

--- a/scripts/lein-modules
+++ b/scripts/lein-modules
@@ -7,6 +7,7 @@ for ext in \
   muuntaja \
   muuntaja-form \
   muuntaja-cheshire \
+  muuntaja-charred \
   muuntaja-msgpack \
   muuntaja-yaml; do
   cd modules/$ext; lein "$@"; cd ../..;

--- a/test/muuntaja/core_test.clj
+++ b/test/muuntaja/core_test.clj
@@ -381,6 +381,7 @@
         (are [format]
           (= data (m/decode m format (m/encode m format data)))
           "application/json"
+          "application/json+cheshire"
           "application/json+charred"
           "application/edn"
           "application/x-yaml"

--- a/test/muuntaja/core_test.clj
+++ b/test/muuntaja/core_test.clj
@@ -16,7 +16,8 @@
            (java.io FileInputStream)
            (java.nio.file Files)))
 
-(defn set-jvm-default-charset! [charset]
+;;; Charset overriding doesn't work on newer JVMs
+#_(defn set-jvm-default-charset! [charset]
   (System/setProperty "file.encoding" charset)
   (doto
     (.getDeclaredField Charset "defaultCharset")
@@ -24,7 +25,7 @@
     (.set nil nil))
   nil)
 
-(defmacro with-default-charset [charset & body]
+#_(defmacro with-default-charset [charset & body]
   `(let [old-charset# (str (Charset/defaultCharset))]
      (try
        (set-jvm-default-charset! ~charset)
@@ -88,7 +89,8 @@
         "application/transit+json"
         "application/transit+msgpack")))
 
-  (testing "charsets"
+  ;;; Charset overriding doesn't work on newer JVMs
+ #_ (testing "charsets"
     (testing "default is UTF-8"
       (is (= "UTF-8" (str (Charset/defaultCharset)))))
     (testing "default can be changed"
@@ -161,7 +163,8 @@
         (testing "utf-8"
           (is (= "{fée: böz}\n" (iso-encoded "application/x-yaml")))
           (is (= "[\"^ \",\"~:fée\",\"böz\"]" (iso-encoded "application/transit+json"))))
-        (testing "when default charset is ISO-8859-1"
+        ;;; Charset overriding does not work on newer JVMs
+       #_ (testing "when default charset is ISO-8859-1"
           (with-default-charset
             "ISO-8859-1"
             (testing "application/x-yaml works"

--- a/test/muuntaja/core_test.clj
+++ b/test/muuntaja/core_test.clj
@@ -7,6 +7,7 @@
             [muuntaja.format.cheshire :as cheshire-format]
             [muuntaja.format.msgpack :as msgpack-format]
             [muuntaja.format.yaml :as yaml-format]
+            [muuntaja.format.charred :as charred-format]
             [jsonista.core :as j]
             [clojure.java.io :as io]
             [muuntaja.protocols :as protocols]
@@ -37,7 +38,8 @@
         (m/install form-format/format)
         (m/install msgpack-format/format)
         (m/install yaml-format/format)
-        (m/install cheshire-format/format "application/json+cheshire"))))
+        (m/install cheshire-format/format "application/json+cheshire")
+        (m/install charred-format/format "application/json+charred"))))
 
 (deftest core-test
   (testing "muuntaja?"
@@ -55,6 +57,7 @@
     (is (= #{"application/edn"
              "application/json"
              "application/json+cheshire"
+             "application/json+charred"
              "application/msgpack"
              "application/transit+json"
              "application/transit+msgpack"
@@ -78,6 +81,7 @@
         (= data (m/decode m format (m/encode m format data)))
         "application/json"
         "application/json+cheshire"
+        "application/json+charred"
         "application/edn"
         "application/x-yaml"
         "application/msgpack"
@@ -99,6 +103,7 @@
                    (m/install msgpack-format/format)
                    (m/install yaml-format/format)
                    (m/install cheshire-format/format "application/json+cheshire")
+                   (m/install charred-format/format "application/json+charred")
                    (assoc :allow-empty-input? false)))]
 
       (testing "by default - nil is returned for empty stream"
@@ -125,6 +130,7 @@
               (thrown-with-msg? Exception #"Malformed" (m/decode m2 format (empty)))
               "application/edn"
               "application/json"
+              "application/json+charred"
               "application/msgpack"
               "application/transit+json"
               "application/transit+msgpack")))
@@ -135,6 +141,7 @@
               (= nil (m/decode m format (empty)))
               "application/json"
               "application/json+cheshire"
+              "application/json+charred"
               "application/edn"
               "application/x-yaml"
               "application/msgpack"
@@ -147,6 +154,7 @@
       (testing "application/json & application/edn use the given charset"
         (is (= "{\"f�e\":\"b�z\"}" (iso-encoded "application/json")))
         (is (= "{\"f�e\":\"b�z\"}" (iso-encoded "application/json+cheshire")))
+        (is (= "{\"f�e\":\"b�z\"}" (iso-encoded "application/json+charred")))
         (is (= "{:f�e \"b�z\"}" (iso-encoded "application/edn"))))
 
       (testing "application/x-yaml & application/transit+json use the platform charset"
@@ -170,6 +178,7 @@
         (= data (encode-decode format))
         "application/json"
         "application/json+cheshire"
+        "application/json+charred"
         "application/edn"
         ;; platform charset
         "application/x-yaml"
@@ -363,12 +372,13 @@
                   (m/install form-format/format)
                   (m/install msgpack-format/format)
                   (m/install yaml-format/format)
-                  (m/install cheshire-format/format "application/json+cheshire")))]
+                  (m/install cheshire-format/format "application/json+cheshire")
+                  (m/install charred-format/format "application/json+charred")))]
       (let [data {:kikka 42, :childs {:facts [1.2 true {:so "nested"}]}}]
         (are [format]
           (= data (m/decode m format (m/encode m format data)))
           "application/json"
-          "application/json+cheshire"
+          "application/json+charred"
           "application/edn"
           "application/x-yaml"
           "application/msgpack"


### PR DESCRIPTION
This PR adds [charred](https://github.com/cnuernber/charred) as a JSON encode/decoder module for muuntaja, like cheshire.

The code comes from a private project that uses muuntaja + reitit.

Open to suggestions for how to test and build it locally in the context of this repo, as well as any change requests.