### PR TITLE
docs: minor fix in Configuration.md

### DIFF
--- a/doc/Configuration.md
+++ b/doc/Configuration.md
@@ -122,7 +122,7 @@ Same with `select-formats`:
       ["application/json"
        "application/edn"])))
 
-(:default-format m)
+(muuntaja/default-format m)
 ; "application/edn"
 ```
 


### PR DESCRIPTION
Hello,

I've been trying to setup Muuntaja in my project and, reading the [Configuration docs](https://github.com/metosin/muuntaja/blob/master/doc/Configuration.md#using-only-selected-formats), have been stuck for a short while on this:

```clojure
parts.server> (def m
  (-> muuntaja/default-options
      (update :formats select-keys ["application/transit+json"])
      (assoc :default-format "application/transit+json")
      muuntaja/create))

;; => #'parts.server/m
parts.server> m
;; => <<Muuntaja>>
parts.server> (:default-format m)
;; => nil
```

It seems that when we inspect a Muuntaja instance directly, we're not seeing the original configuration map, but rather an instantiated object where the properties aren't directly accessible through keywords.

This way of inspecting configuration worked for me, though:

```clojure
parts.server> (muuntaja/default-format m)
;; => "application/transit+json"
```

Hopefully this will help some other beginner in the future, too.

Thank you for building Muuntaja!